### PR TITLE
Update gcc7 to -il-2

### DIFF
--- a/build/gcc7/build.sh
+++ b/build/gcc7/build.sh
@@ -20,7 +20,7 @@
 PKG=developer/gcc7
 PROG=gcc
 VER=7.5.0
-ILVER=il-1
+ILVER=il-2
 SUMMARY="gcc $VER-$ILVER"
 DESC="The GNU Compiler Collection"
 

--- a/build/gcc7/patches/0032-cmn_err-supports-h-and-hh.patch
+++ b/build/gcc7/patches/0032-cmn_err-supports-h-and-hh.patch
@@ -1,0 +1,75 @@
+From cfdc7629305ff10e1c0159894526734ed52e6e10 Mon Sep 17 00:00:00 2001
+From: Andy Fiddaman <illumos@fiddaman.net>
+Date: Mon, 28 Nov 2022 11:52:58 +0000
+Subject: cmn_err() supports 'h' and 'hh'
+
+---
+ gcc/config/sol2-c.c                     | 21 ++++++++++++---------
+ gcc/testsuite/gcc.dg/format/cmn-err-1.c |  5 +++++
+ 2 files changed, 17 insertions(+), 9 deletions(-)
+
+diff --git a/gcc/config/sol2-c.c b/gcc/config/sol2-c.c
+index 3519818d792..4640a3fd795 100644
+--- a/gcc/config/sol2-c.c
++++ b/gcc/config/sol2-c.c
+@@ -31,11 +31,13 @@ along with GCC; see the file COPYING3.  If not see
+ 
+ #include "c-family/c-pragma.h"
+ 
+-/* cmn_err only accepts "l" and "ll".  */
++#define NO_FMT NULL, FMT_LEN_none, STD_C89
++
+ static const format_length_info cmn_err_length_specs[] =
+ {
++  { "h", FMT_LEN_h, STD_C89, "hh", FMT_LEN_hh, STD_C99, 0 },
+   { "l", FMT_LEN_l, STD_C89, "ll", FMT_LEN_ll, STD_C89, 0 },
+-  { NULL, FMT_LEN_none, STD_C89, NULL, FMT_LEN_none, STD_C89, 0 }
++  { NO_FMT, NO_FMT, 0 }
+ };
+ 
+ static const format_flag_spec cmn_err_flag_specs[] =
+@@ -60,14 +62,15 @@ static const format_char_info bitfield_string_type =
+ 
+ static const format_char_info cmn_err_char_table[] =
+ {
++  /*                     none     hh       h        l        ll       L        z        t        j        H       D       DD */
+   /* C89 conversion specifiers.  */
+-  { "dD",  0, STD_C89, { T89_I,   BADLEN,  BADLEN,  T89_L,   T9L_LL,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-wp0", "",   NULL },
+-  { "oOxX",0, STD_C89, { T89_UI,  BADLEN,  BADLEN,  T89_UL,  T9L_ULL, BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-wp0", "",   NULL },
+-  { "u",   0, STD_C89, { T89_UI,  BADLEN,  BADLEN,  T89_UL,  T9L_ULL, BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-wp0", "",   NULL },
+-  { "c",   0, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "",   NULL },
+-  { "p",   1, STD_C89, { T89_V,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "c",  NULL },
+-  { "s",   1, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-wp",  "cR", NULL },
+-  { "b",   0, STD_C89, { T89_I,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w0",  "",   &bitfield_string_type },
++  { "dD",  0, STD_C89, { T89_I,   T99_SC,  T89_S,   T89_L,   T9L_LL,  BADLEN,  BADLEN,  BADLEN,  BADLEN , BADLEN, BADLEN, BADLEN }, "-wp0", "",   NULL },
++  { "oOxX",0, STD_C89, { T89_UI,  T99_UC,  T89_US,  T89_UL,  T9L_ULL, BADLEN,  BADLEN,  BADLEN,  BADLEN , BADLEN, BADLEN, BADLEN }, "-wp0", "",   NULL },
++  { "u",   0, STD_C89, { T89_UI,  T99_UC,  T89_US,  T89_UL,  T9L_ULL, BADLEN,  BADLEN,  BADLEN,  BADLEN , BADLEN, BADLEN, BADLEN }, "-wp0", "",   NULL },
++  { "c",   0, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN , BADLEN, BADLEN, BADLEN }, "-w",   "",   NULL },
++  { "p",   1, STD_C89, { T89_V,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN , BADLEN, BADLEN, BADLEN }, "-w",   "c",  NULL },
++  { "s",   1, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN , BADLEN, BADLEN, BADLEN }, "-wp",  "cR", NULL },
++  { "b",   0, STD_C89, { T89_I,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN , BADLEN, BADLEN, BADLEN }, "-w0",  "",   &bitfield_string_type },
+   { NULL,  0, STD_C89, NOLENGTHS, NULL, NULL, NULL }
+ };
+ 
+diff --git a/gcc/testsuite/gcc.dg/format/cmn-err-1.c b/gcc/testsuite/gcc.dg/format/cmn-err-1.c
+index aea7779a2c3..f6833c1723a 100644
+--- a/gcc/testsuite/gcc.dg/format/cmn-err-1.c
++++ b/gcc/testsuite/gcc.dg/format/cmn-err-1.c
+@@ -17,12 +17,17 @@ int main()
+   int i = 1;
+   long l = 2;
+   llong ll = 3;
++  char hh = 4;
++  short h = 5;
+ 
+   cmn_err_func (0, "%s", string);
+   cmn_err_func (0, "%d %D %o %O %x %X %u", i, i, i, i, i, i, i);
+   cmn_err_func (0, "%ld %lD %lo %lO %lx %lX %lu", l, l, l, l, l, l, l);
+   cmn_err_func (0, "%lld %llD %llo %llO %llx %llX %llu",
+ 		ll, ll, ll, ll, ll, ll, ll);
++  cmn_err_func (0, "%hd %hD %ho %hO %hx %hX %hu", h, h, h, h, h, h, h);
++  cmn_err_func (0, "%hhd %hhD %hho %hhO %hhx %hhX %hhu",
++		hh, hh, hh, hh, hh, hh, hh);
+   cmn_err_func (0, "%b %s", i, "\01Foo", string);
+   cmn_err_func (0, "%p", string);
+   cmn_err_func (0, "%16b", i, "\01Foo");

--- a/build/gcc7/patches/0033-OOCE-Adjust-default-library-paths-for-OmniOS.patch
+++ b/build/gcc7/patches/0033-OOCE-Adjust-default-library-paths-for-OmniOS.patch
@@ -1,4 +1,4 @@
-From 9fe3dce1bf669c4cff700d74fb82d4bea16b7219 Mon Sep 17 00:00:00 2001
+From 5c4c0a3c9a95dddcedaa3cee2b5b9ad8a2897cac Mon Sep 17 00:00:00 2001
 From: Andy Fiddaman <omnios@citrus-it.co.uk>
 Date: Thu, 9 May 2019 13:43:30 +0000
 Subject: OOCE: Adjust default library paths for OmniOS

--- a/build/gcc7/patches/series
+++ b/build/gcc7/patches/series
@@ -28,4 +28,5 @@
 0029-13185-zassert-deflib-does-not-work-for-64-bit-object.patch
 0030-Add-__illumos__-preprocessor-definition.patch
 0031-libstdc-must-use-thread-local-errno.patch
-0032-OOCE-Adjust-default-library-paths-for-OmniOS.patch
+0032-cmn_err-supports-h-and-hh.patch
+0033-OOCE-Adjust-default-library-paths-for-OmniOS.patch


### PR DESCRIPTION
This adds a patch to allow the use of `%h` and `%hh` in kernel printf/cmn_err code, and aligns our gcc7 with the illumos -il-2 tag.