### PR TITLE
screen - update from 4.9.0 to 4.9.1

### DIFF
--- a/build/screen/build.sh
+++ b/build/screen/build.sh
@@ -13,12 +13,12 @@
 # }}}
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/build.sh
 
 PROG=screen
-VER=4.9.0
+VER=4.9.1
 PKG=terminal/screen
 SUMMARY="GNU Screen terminal multiplexer"
 DESC="A full-screen window manager that multiplexes a physical "

--- a/build/screen/patches/Makefile.in.patch
+++ b/build/screen/patches/Makefile.in.patch
@@ -1,4 +1,4 @@
-diff -wpruN '--exclude=*.orig' a~/Makefile.in a/Makefile.in
+diff -wpruN --no-dereference '--exclude=*.orig' a~/Makefile.in a/Makefile.in
 --- a~/Makefile.in	1970-01-01 00:00:00
 +++ a/Makefile.in	1970-01-01 00:00:00
 @@ -17,7 +17,7 @@ datarootdir = @datarootdir@

--- a/build/screen/patches/ncurses.patch
+++ b/build/screen/patches/ncurses.patch
@@ -2,24 +2,24 @@ This patch makes configure check for ncurses before curses so that screen
 can take advantage of the latest terminal type information from our
 ncurses package.
 
-diff -wpruN '--exclude=*.orig' a~/configure.ac a/configure.ac
+diff -wpruN --no-dereference '--exclude=*.orig' a~/configure.ac a/configure.ac
 --- a~/configure.ac	1970-01-01 00:00:00
 +++ a/configure.ac	1970-01-01 00:00:00
-@@ -626,7 +626,7 @@ dnl
- AC_CHECKING(for tgetent)
- AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
+@@ -669,7 +669,7 @@ AC_TRY_LINK([
+     tgetent((char *)0, (char *)0);
+ ],,
  olibs="$LIBS"
 -LIBS="-lcurses $olibs"
 +LIBS="-lncurses $olibs"
  AC_CHECKING(libcurses)
- AC_TRY_LINK(,[
- #ifdef __hpux
-@@ -647,7 +647,7 @@ AC_TRY_LINK(,tgetent((char *)0, (char *)
- LIBS="-ltinfow $olibs"
- AC_CHECKING(libtinfow)
- AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
+ AC_TRY_LINK([
+     #include <curses.h>
+@@ -713,7 +713,7 @@ AC_TRY_LINK([
+ ],[
+     tgetent((char *)0, (char *)0);
+ ],,
 -LIBS="-lncurses $olibs"
 +LIBS="-lcurses $olibs"
  AC_CHECKING(libncurses)
- AC_TRY_LINK(,tgetent((char *)0, (char *)0);,,
- LIBS="-ltinfo $olibs"
+ AC_TRY_LINK([
+     #include <curses.h>

--- a/build/screen/patches/unneededlibs.patch
+++ b/build/screen/patches/unneededlibs.patch
@@ -1,16 +1,16 @@
-diff -wpruN '--exclude=*.orig' a~/configure.ac a/configure.ac
+diff -wpruN --no-dereference '--exclude=*.orig' a~/configure.ac a/configure.ac
 --- a~/configure.ac	1970-01-01 00:00:00
 +++ a/configure.ac	1970-01-01 00:00:00
-@@ -188,7 +188,7 @@ AC_EGREP_CPP(yes,
+@@ -189,7 +189,7 @@ AC_EGREP_CPP(yes,
  ], AC_NOTE(- you have a SVR4 system) AC_DEFINE(SVR4) svr4=1)
  if test -n "$svr4" ; then
  oldlibs="$LIBS"
 -LIBS="$LIBS -lelf"
 +LIBS="$LIBS"
  AC_CHECKING(SVR4)
- AC_TRY_LINK([#include <utmpx.h>
- ],,
-@@ -204,7 +204,7 @@ AC_EGREP_CPP(YES_IS_DEFINED,
+ AC_TRY_LINK([
+     #include <utmpx.h>
+@@ -206,7 +206,7 @@ AC_EGREP_CPP(YES_IS_DEFINED,
  [#if defined(SVR4) && defined(sun)
    YES_IS_DEFINED;
  #endif


### PR DESCRIPTION
A new version of screen is out with a fix for https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-24626
`screen` is not installed as setuid/setgid on helios but I'm pulling this update from OmniOS in an abundance of caution, since it is being backported to all supported releases there.