### PR TITLE
curl - update from 8.1.2 to 8.3.0

### DIFF
--- a/build/curl/build.sh
+++ b/build/curl/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/build.sh
 
 PROG=curl
-VER=8.1.2
+VER=8.3.0
 PKG=web/curl
 SUMMARY="Command line tool for transferring data with URL syntax"
 DESC="Curl is a command line tool for transferring data with URL syntax, "

--- a/build/curl/testsuite.log
+++ b/build/curl/testsuite.log
@@ -1,3 +1,3 @@
-TESTDONE: 1593 tests were considered during 506 seconds.
-TESTDONE: 1286 tests out of 1287 reported OK: 99%
+TESTDONE: 1635 tests were considered during 382 seconds.
+TESTDONE: 1318 tests out of 1319 reported OK: 99%
 TESTFAIL: These test cases failed: 1004 


### PR DESCRIPTION
This update includes a fix for https://curl.se/docs/CVE-2023-38039.html