### PR TITLE
openssl - update from 3.0.10 to 3.0.11

### DIFF
--- a/build/openssl/build-3.sh
+++ b/build/openssl/build-3.sh
@@ -19,7 +19,7 @@
 . common.sh
 
 PROG=openssl
-VER=3.0.10
+VER=3.0.11
 PKG=library/security/openssl-3
 SUMMARY="Cryptography and SSL/TLS Toolkit"
 DESC="A toolkit for Secure Sockets Layer and Transport Layer protocols "

--- a/build/openssl/testsuite-3.log
+++ b/build/openssl/testsuite-3.log
@@ -252,5 +252,5 @@ Result: NOTESTS
 99-test_fuzz_server.t .............. ok
 99-test_fuzz_x509.t ................ ok
 All tests successful.
-Files=250, Tests=3322, 
+Files=250, Tests=3327, 
 Result: PASS


### PR DESCRIPTION
The only security fix in this update is:
```
POLY1305 MAC implementation corrupts XMM registers on Windows (CVE-2023-4807)
```
which is not relevant for helios.

https://www.openssl.org/news/secadv/20230908.txt