### PR TITLE
curl - update from 8.3.0 to 8.4.0

### DIFF
--- a/build/curl/build.sh
+++ b/build/curl/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/build.sh
 
 PROG=curl
-VER=8.3.0
+VER=8.4.0
 PKG=web/curl
 SUMMARY="Command line tool for transferring data with URL syntax"
 DESC="Curl is a command line tool for transferring data with URL syntax, "

--- a/build/curl/patches/tests.patch
+++ b/build/curl/patches/tests.patch
@@ -9,8 +9,8 @@ diff -wpruN '--exclude=*.orig' a~/tests/data/test1004 a/tests/data/test1004
 +++ a/tests/data/test1004	1970-01-01 00:00:00
 @@ -39,7 +39,7 @@ http
  HTTP GET with empty proxy
-  </name>
-  <command>
+ </name>
+ <command>
 -http://%HOSTIP:%HTTPPORT/%TESTNUMBER --proxy ""
 +http://%HOSTIP:%HTTPPORT/%TESTNUMBER --proxy "''"
  </command>
@@ -45,8 +45,8 @@ diff -wpruN '--exclude=*.orig' a~/tests/data/test355 a/tests/data/test355
 +++ a/tests/data/test355	1970-01-01 00:00:00
 @@ -34,7 +34,7 @@ http
  load Alt-Svc from file and use
-  </name>
-  <command>
+ </name>
+ <command>
 -http://%HOSTIP:%HTTPPORT/%TESTNUMBER --alt-svc ""
 +http://%HOSTIP:%HTTPPORT/%TESTNUMBER --alt-svc "''"
  </command>

--- a/build/curl/testsuite.log
+++ b/build/curl/testsuite.log
@@ -1,3 +1,3 @@
-TESTDONE: 1635 tests were considered during 382 seconds.
-TESTDONE: 1318 tests out of 1319 reported OK: 99%
+TESTDONE: 1646 tests were considered during 514 seconds.
+TESTDONE: 1327 tests out of 1328 reported OK: 99%
 TESTFAIL: These test cases failed: 1004 


### PR DESCRIPTION
* `curl` updated to version 8.4.0, fixing
  [CVE-2023-38545](https://curl.se/docs/CVE-2023-38545.html),
  [CVE-2023-38546](https://curl.se/docs/CVE-2023-38546.html).