### PR TITLE
openssl - update from 3.0.11 to 3.0.12

### DIFF
--- a/build/openssl/build-3.sh
+++ b/build/openssl/build-3.sh
@@ -19,7 +19,7 @@
 . common.sh
 
 PROG=openssl
-VER=3.0.11
+VER=3.0.12
 PKG=library/security/openssl-3
 SUMMARY="Cryptography and SSL/TLS Toolkit"
 DESC="A toolkit for Secure Sockets Layer and Transport Layer protocols "

--- a/build/openssl/patches-3/cross-aarch64.patch
+++ b/build/openssl/patches-3/cross-aarch64.patch
@@ -1,4 +1,4 @@
-diff -wpruN --no-dereference '--exclude=*.orig' a~/Configurations/15-illumos-aarch.conf a/Configurations/15-illumos-aarch.conf
+diff -wpruN '--exclude=*.orig' a~/Configurations/15-illumos-aarch.conf a/Configurations/15-illumos-aarch.conf
 --- a~/Configurations/15-illumos-aarch.conf	1970-01-01 00:00:00
 +++ a/Configurations/15-illumos-aarch.conf	1970-01-01 00:00:00
 @@ -0,0 +1,17 @@

--- a/build/openssl/patches-3/libs.patch
+++ b/build/openssl/patches-3/libs.patch
@@ -14,10 +14,10 @@ patch the configuration script to stop linking against these two libraries.
 We also patch out the desire to omit the frame pointer and add in dwarf-2
 debug information which can be converted to CTF.
 
-diff -wpruN --no-dereference '--exclude=*.orig' a~/Configurations/10-main.conf a/Configurations/10-main.conf
+diff -wpruN '--exclude=*.orig' a~/Configurations/10-main.conf a/Configurations/10-main.conf
 --- a~/Configurations/10-main.conf	1970-01-01 00:00:00
 +++ a/Configurations/10-main.conf	1970-01-01 00:00:00
-@@ -210,7 +210,7 @@ my %targets = (
+@@ -213,7 +213,7 @@ my %targets = (
          inherit_from     => [ "BASE_unix" ],
          template         => 1,
          lib_cppflags     => "-DFILIO_H",
@@ -26,7 +26,7 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/Configurations/10-main.conf a
          dso_scheme       => "dlfcn",
          thread_scheme    => "pthreads",
      },
-@@ -238,7 +238,7 @@ my %targets = (
+@@ -241,7 +241,7 @@ my %targets = (
          CC               => "gcc",
          CFLAGS           => add_before(picker(default => "-Wall",
                                                debug   => "-O0 -g",
@@ -35,7 +35,7 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/Configurations/10-main.conf a
          cflags           => add(threads("-pthread")),
          lib_cppflags     => add("-DL_ENDIAN"),
          ex_libs          => add(threads("-pthread")),
-@@ -261,7 +261,7 @@ my %targets = (
+@@ -264,7 +264,7 @@ my %targets = (
          CC               => "gcc",
          CFLAGS           => add_before(picker(default => "-Wall",
                                                debug   => "-O0 -g",

--- a/build/openssl/testsuite-3.log
+++ b/build/openssl/testsuite-3.log
@@ -252,5 +252,5 @@ Result: NOTESTS
 99-test_fuzz_server.t .............. ok
 99-test_fuzz_x509.t ................ ok
 All tests successful.
-Files=250, Tests=3327, 
+Files=250, Tests=3328, 
 Result: PASS


### PR DESCRIPTION
Here is the only documented change between these two versions:

 * Fix incorrect key and IV resizing issues when calling EVP_EncryptInit_ex2(),
   EVP_DecryptInit_ex2() or EVP_CipherInit_ex2() with OSSL_PARAM parameters
   that alter the key or IV length ([CVE-2023-5363]).

This is described in https://www.openssl.org/news/secadv/20231024.txt
