### PR TITLE
openjdk11: update from 11.0.19+7 to 11.0.21+9

### DIFF
--- a/build/openjdk11/patches/omnios-headless.patch
+++ b/build/openjdk11/patches/omnios-headless.patch
@@ -1,7 +1,7 @@
 diff -wpruN --no-dereference '--exclude=*.orig' a~/make/lib/Awt2dLibraries.gmk a/make/lib/Awt2dLibraries.gmk
 --- a~/make/lib/Awt2dLibraries.gmk	1970-01-01 00:00:00
 +++ a/make/lib/Awt2dLibraries.gmk	1970-01-01 00:00:00
-@@ -734,11 +734,9 @@ else # not windows
+@@ -735,11 +735,9 @@ else # not windows
        JAWT_LIBS += -lawt_xawt
      else
        JAWT_LIBS += -lawt_headless

--- a/build/openjdk11/patches/patch-make_lib_Awt2dLibraries.gmk
+++ b/build/openjdk11/patches/patch-make_lib_Awt2dLibraries.gmk
@@ -14,11 +14,11 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/make/lib/Awt2dLibraries.gmk a
      EXTRA_HEADER_DIRS := \
          common/awt/debug \
 @@ -554,8 +553,12 @@ else
-     HARFBUZZ_CFLAGS += -DHAVE_INTEL_ATOMIC_PRIMITIVES
+     HARFBUZZ_CFLAGS += -DHAVE_INTEL_ATOMIC_PRIMITIVES -DHB_NO_VISIBILITY
    endif
    ifeq ($(call isTargetOs, solaris), true)
 +   ifeq ($(TOOLCHAIN_TYPE), gcc)
-+    HARFBUZZ_CFLAGS += -DHAVE_INTEL_ATOMIC_PRIMITIVES
++    HARFBUZZ_CFLAGS += -DHAVE_INTEL_ATOMIC_PRIMITIVES -DHB_NO_VISIBILITY
 +   else
      HARFBUZZ_CFLAGS += -DHAVE_SOLARIS_ATOMIC_OPS
    endif

--- a/build/openjdk11/patches/series
+++ b/build/openjdk11/patches/series
@@ -36,6 +36,7 @@ tribblix-flags-ldflags2.patch
 tribblix-flags-ldflags3.patch
 tribblix-Launcher-jdk.patch
 tribblix-LauncherCommon.patch
+tribblix-thrstat001.patch
 omnios-headless.patch
 security-pkcs11.patch
 fontpath.patch

--- a/build/openjdk11/patches/tribblix-thrstat001.patch
+++ b/build/openjdk11/patches/tribblix-thrstat001.patch
@@ -1,0 +1,22 @@
+Local definition of wait() conflicts with wait(3C).
+
+--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadState/thrstat001/thrstat001.cpp	Fri Oct  6 06:33:33 2023
++++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadState/thrstat001/thrstat001.cpp	Thu Oct 19 09:25:58 2023
+@@ -70,7 +70,7 @@
+ }
+ 
+ static void
+-wait(const char* func_name, jrawMonitorID lock, jint millis) {
++thrstat001wait(const char* func_name, jrawMonitorID lock, jint millis) {
+     jvmtiError err = jvmti->RawMonitorWait(lock, (jlong)millis);
+     if (err != JVMTI_ERROR_NONE) {
+         printf("%s: unexpected error in RawMonitorWait: %s (%d)\n",
+@@ -229,7 +229,7 @@
+             break;
+         }
+         lock("checkStatus", wait_lock);
+-        wait("checkStatus", wait_lock, millis);
++        thrstat001wait("checkStatus", wait_lock, millis);
+         unlock("checkStatus", wait_lock);
+     }
+ 


### PR DESCRIPTION
Bumping OpenJDK11 several versions by importing updates from OmniOS (which has itself taken updates from tribblix). We need OpenJDK11 to build `bazel`.