### PR TITLE
Unzip was not building with bzip2 support

### DIFF
--- a/build/unzip/build.sh
+++ b/build/unzip/build.sh
@@ -31,8 +31,10 @@ HARDLINK_TARGETS="
 "
 SKIP_LICENCES="*"
 
-# Copied from upstream's pkg makefile
-export LOCAL_UNZIP="-DUNICODE_SUPPORT -DNO_WORKING_ISPRINT -DUNICODE_WCHAR"
+CONFIGURE_OPTS="
+    -DWILD_STOP_AT_DIR
+"
+export LOCAL_UNZIP="${CONFIGURE_OPTS[0]//$'\n'/}"
 
 configure_amd64() {
     export i386
@@ -48,6 +50,7 @@ configure_aarch64() {
 }
 
 pre_install() {
+    ldd $PROG | $EGREP -s libbz2 || logerr "unzip was built without bzip2"
     save_variable MAKE_INSTALL_ARGS
     MAKE_INSTALL_ARGS+=" prefix=$DESTDIR$PREFIX"
 }
@@ -58,7 +61,7 @@ post_install() {
 
 
 BASE_MAKE_ARGS="-f unix/Makefile"
-MAKE_ARGS="$BASE_MAKE_ARGS generic IZ_BZIP2=bzip2"
+MAKE_ARGS="$BASE_MAKE_ARGS generic"
 MAKE_INSTALL_ARGS="$BASE_MAKE_ARGS install"
 
 init

--- a/build/unzip/build.sh
+++ b/build/unzip/build.sh
@@ -50,7 +50,7 @@ configure_aarch64() {
 }
 
 pre_install() {
-    $ELFEDIT -e dyn:dump -o simple $PROG | $EGREP -s 'libbz2\.so' \
+    $ELFEDIT -r -e 'dyn:tag NEEDED' -o simple $PROG | $EGREP -s 'libbz2\.so' \
         || logerr "unzip was built without bzip2"
     save_variable MAKE_INSTALL_ARGS
     MAKE_INSTALL_ARGS+=" prefix=$DESTDIR$PREFIX"

--- a/build/unzip/build.sh
+++ b/build/unzip/build.sh
@@ -50,7 +50,8 @@ configure_aarch64() {
 }
 
 pre_install() {
-    ldd $PROG | $EGREP -s libbz2 || logerr "unzip was built without bzip2"
+    $ELFEDIT -e dyn:dump -o simple $PROG | $EGREP -s 'libbz2\.so' \
+        || logerr "unzip was built without bzip2"
     save_variable MAKE_INSTALL_ARGS
     MAKE_INSTALL_ARGS+=" prefix=$DESTDIR$PREFIX"
 }

--- a/build/unzip/patches/CVE-2014-8139-crc-overflow.patch
+++ b/build/unzip/patches/CVE-2014-8139-crc-overflow.patch
@@ -1,4 +1,4 @@
-diff -wpruN '--exclude=*.orig' a~/extract.c a/extract.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/extract.c a/extract.c
 --- a~/extract.c	1970-01-01 00:00:00
 +++ a/extract.c	1970-01-01 00:00:00
 @@ -1,5 +1,5 @@

--- a/build/unzip/patches/CVE-2014-8140-test-compr-eb.patch
+++ b/build/unzip/patches/CVE-2014-8140-test-compr-eb.patch
@@ -1,4 +1,4 @@
-diff -wpruN '--exclude=*.orig' a~/extract.c a/extract.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/extract.c a/extract.c
 --- a~/extract.c	1970-01-01 00:00:00
 +++ a/extract.c	1970-01-01 00:00:00
 @@ -2232,10 +2232,17 @@ static int test_compr_eb(__G__ eb, eb_si

--- a/build/unzip/patches/CVE-2014-8141-getzip64data.patch
+++ b/build/unzip/patches/CVE-2014-8141-getzip64data.patch
@@ -1,4 +1,4 @@
-diff -wpruN '--exclude=*.orig' a~/fileio.c a/fileio.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/fileio.c a/fileio.c
 --- a~/fileio.c	1970-01-01 00:00:00
 +++ a/fileio.c	1970-01-01 00:00:00
 @@ -176,6 +176,8 @@ static ZCONST char Far FilenameTooLongTr
@@ -24,7 +24,7 @@ diff -wpruN '--exclude=*.orig' a~/fileio.c a/fileio.c
  #ifdef UNICODE_SUPPORT
              G.unipath_filename = NULL;
              if (G.UzO.U_flag < 2) {
-diff -wpruN '--exclude=*.orig' a~/process.c a/process.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/process.c a/process.c
 --- a~/process.c	1970-01-01 00:00:00
 +++ a/process.c	1970-01-01 00:00:00
 @@ -1,5 +1,5 @@

--- a/build/unzip/patches/CVE-2014-9636-test-compr-eb.patch
+++ b/build/unzip/patches/CVE-2014-9636-test-compr-eb.patch
@@ -1,4 +1,4 @@
-diff -wpruN '--exclude=*.orig' a~/extract.c a/extract.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/extract.c a/extract.c
 --- a~/extract.c	1970-01-01 00:00:00
 +++ a/extract.c	1970-01-01 00:00:00
 @@ -2228,6 +2228,7 @@ static int test_compr_eb(__G__ eb, eb_si

--- a/build/unzip/patches/CVE-2014-9913-unzip-buffer-overflow.patch
+++ b/build/unzip/patches/CVE-2014-9913-unzip-buffer-overflow.patch
@@ -5,7 +5,7 @@ Bug-Debian: https://bugs.debian.org/847485
 Bug-Ubuntu: https://launchpad.net/bugs/387350
 X-Debian-version: 6.0-21
 
-diff -wpruN '--exclude=*.orig' a~/list.c a/list.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/list.c a/list.c
 --- a~/list.c	1970-01-01 00:00:00
 +++ a/list.c	1970-01-01 00:00:00
 @@ -339,7 +339,18 @@ int list_files(__G)    /* return PK-type

--- a/build/unzip/patches/CVE-2015-7696-heap-overflow.patch
+++ b/build/unzip/patches/CVE-2015-7696-heap-overflow.patch
@@ -5,7 +5,7 @@ Bug-Debian: https://bugs.debian.org/802162
 Bug-RedHat: https://bugzilla.redhat.com/show_bug.cgi?id=1260944
 Origin: https://bugzilla.redhat.com/attachment.cgi?id=1073002
 
-diff -wpruN '--exclude=*.orig' a~/crypt.c a/crypt.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/crypt.c a/crypt.c
 --- a~/crypt.c	1970-01-01 00:00:00
 +++ a/crypt.c	1970-01-01 00:00:00
 @@ -465,7 +465,17 @@ int decrypt(__G__ passwrd)

--- a/build/unzip/patches/CVE-2015-7697-infinite-loop.patch
+++ b/build/unzip/patches/CVE-2015-7697-infinite-loop.patch
@@ -5,7 +5,7 @@ Bug-Debian: https://bugs.debian.org/802160
 Bug-RedHat: https://bugzilla.redhat.com/show_bug.cgi?id=1260944
 Origin: other, https://bugzilla.redhat.com/attachment.cgi?id=1073339
 
-diff -wpruN '--exclude=*.orig' a~/extract.c a/extract.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/extract.c a/extract.c
 --- a~/extract.c	1970-01-01 00:00:00
 +++ a/extract.c	1970-01-01 00:00:00
 @@ -2728,6 +2728,12 @@ __GDEF

--- a/build/unzip/patches/CVE-2016-9844-zipinfo-buffer-overflow.patch
+++ b/build/unzip/patches/CVE-2016-9844-zipinfo-buffer-overflow.patch
@@ -4,7 +4,7 @@ Bug-Debian: https://bugs.debian.org/847486
 Bug-Ubuntu: https://launchpad.net/bugs/1643750
 X-Debian-version: 6.0-21
 
-diff -wpruN '--exclude=*.orig' a~/zipinfo.c a/zipinfo.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/zipinfo.c a/zipinfo.c
 --- a~/zipinfo.c	1970-01-01 00:00:00
 +++ a/zipinfo.c	1970-01-01 00:00:00
 @@ -1921,7 +1921,18 @@ static int zi_short(__G)   /* return PK-

--- a/build/unzip/patches/CVE-2018-1000035-overflow-password-protect.patch
+++ b/build/unzip/patches/CVE-2018-1000035-overflow-password-protect.patch
@@ -1,4 +1,4 @@
-diff -wpruN '--exclude=*.orig' a~/fileio.c a/fileio.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/fileio.c a/fileio.c
 --- a~/fileio.c	1970-01-01 00:00:00
 +++ a/fileio.c	1970-01-01 00:00:00
 @@ -1,5 +1,5 @@

--- a/build/unzip/patches/CVE-2019-13232a.patch
+++ b/build/unzip/patches/CVE-2019-13232a.patch
@@ -1,0 +1,22 @@
+From: Mark Adler <madler@alumni.caltech.edu>
+Subject: Fix bug in undefer_input() that misplaced the input state.
+Origin: https://github.com/madler/unzip/commit/41beb477c5744bc396fa1162ee0c14218ec12213
+Bug-Debian: https://bugs.debian.org/931433
+X-Debian-version: 6.0-24
+
+    Fix bug in undefer_input() that misplaced the input state.
+
+--- a/fileio.c
++++ b/fileio.c
+@@ -532,8 +532,10 @@
+          * This condition was checked when G.incnt_leftover was set > 0 in
+          * defer_leftover_input(), and it is NOT allowed to touch G.csize
+          * before calling undefer_input() when (G.incnt_leftover > 0)
+-         * (single exception: see read_byte()'s  "G.csize <= 0" handling) !!
++         * (single exception: see readbyte()'s  "G.csize <= 0" handling) !!
+          */
++        if (G.csize < 0L)
++            G.csize = 0L;
+         G.incnt = G.incnt_leftover + (int)G.csize;
+         G.inptr = G.inptr_leftover - (int)G.csize;
+         G.incnt_leftover = 0;

--- a/build/unzip/patches/CVE-2019-13232a.patch
+++ b/build/unzip/patches/CVE-2019-13232a.patch
@@ -6,9 +6,10 @@ X-Debian-version: 6.0-24
 
     Fix bug in undefer_input() that misplaced the input state.
 
---- a/fileio.c
-+++ b/fileio.c
-@@ -532,8 +532,10 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/fileio.c a/fileio.c
+--- a~/fileio.c	1970-01-01 00:00:00
++++ a/fileio.c	1970-01-01 00:00:00
+@@ -532,8 +532,10 @@ void undefer_input(__G)
           * This condition was checked when G.incnt_leftover was set > 0 in
           * defer_leftover_input(), and it is NOT allowed to touch G.csize
           * before calling undefer_input() when (G.incnt_leftover > 0)

--- a/build/unzip/patches/CVE-2019-13232b.patch
+++ b/build/unzip/patches/CVE-2019-13232b.patch
@@ -1,0 +1,335 @@
+From: Mark Adler <madler@alumni.caltech.edu>
+Subject: Detect and reject a zip bomb using overlapped entries.
+Origin: https://github.com/madler/unzip/commit/47b3ceae397d21bf822bc2ac73052a4b1daf8e1c
+Bug-Debian: https://bugs.debian.org/931433
+X-Debian-version: 6.0-24
+
+    Detect and reject a zip bomb using overlapped entries.
+    
+    This detects an invalid zip file that has at least one entry that
+    overlaps with another entry or with the central directory to the
+    end of the file. A Fifield zip bomb uses overlapped local entries
+    to vastly increase the potential inflation ratio. Such an invalid
+    zip file is rejected.
+    
+    See https://www.bamsoftware.com/hacks/zipbomb/ for David Fifield's
+    analysis, construction, and examples of such zip bombs.
+    
+    The detection maintains a list of covered spans of the zip files
+    so far, where the central directory to the end of the file and any
+    bytes preceding the first entry at zip file offset zero are
+    considered covered initially. Then as each entry is decompressed
+    or tested, it is considered covered. When a new entry is about to
+    be processed, its initial offset is checked to see if it is
+    contained by a covered span. If so, the zip file is rejected as
+    invalid.
+    
+    This commit depends on a preceding commit: "Fix bug in
+    undefer_input() that misplaced the input state."
+
+--- a/extract.c
++++ b/extract.c
+@@ -321,6 +321,125 @@
+   "\nerror:  unsupported extra-field compression type (%u)--skipping\n";
+ static ZCONST char Far BadExtraFieldCRC[] =
+   "error [%s]:  bad extra-field CRC %08lx (should be %08lx)\n";
++static ZCONST char Far NotEnoughMemCover[] =
++  "error: not enough memory for bomb detection\n";
++static ZCONST char Far OverlappedComponents[] =
++  "error: invalid zip file with overlapped components (possible zip bomb)\n";
++
++
++
++
++
++/* A growable list of spans. */
++typedef zoff_t bound_t;
++typedef struct {
++    bound_t beg;        /* start of the span */
++    bound_t end;        /* one past the end of the span */
++} span_t;
++typedef struct {
++    span_t *span;       /* allocated, distinct, and sorted list of spans */
++    size_t num;         /* number of spans in the list */
++    size_t max;         /* allocated number of spans (num <= max) */
++} cover_t;
++
++/*
++ * Return the index of the first span in cover whose beg is greater than val.
++ * If there is no such span, then cover->num is returned.
++ */
++static size_t cover_find(cover, val)
++    cover_t *cover;
++    bound_t val;
++{
++    size_t lo = 0, hi = cover->num;
++    while (lo < hi) {
++        size_t mid = (lo + hi) >> 1;
++        if (val < cover->span[mid].beg)
++            hi = mid;
++        else
++            lo = mid + 1;
++    }
++    return hi;
++}
++
++/* Return true if val lies within any one of the spans in cover. */
++static int cover_within(cover, val)
++    cover_t *cover;
++    bound_t val;
++{
++    size_t pos = cover_find(cover, val);
++    return pos > 0 && val < cover->span[pos - 1].end;
++}
++
++/*
++ * Add a new span to the list, but only if the new span does not overlap any
++ * spans already in the list. The new span covers the values beg..end-1. beg
++ * must be less than end.
++ *
++ * Keep the list sorted and merge adjacent spans. Grow the allocated space for
++ * the list as needed. On success, 0 is returned. If the new span overlaps any
++ * existing spans, then 1 is returned and the new span is not added to the
++ * list. If the new span is invalid because beg is greater than or equal to
++ * end, then -1 is returned. If the list needs to be grown but the memory
++ * allocation fails, then -2 is returned.
++ */
++static int cover_add(cover, beg, end)
++    cover_t *cover;
++    bound_t beg;
++    bound_t end;
++{
++    size_t pos;
++    int prec, foll;
++
++    if (beg >= end)
++    /* The new span is invalid. */
++        return -1;
++
++    /* Find where the new span should go, and make sure that it does not
++       overlap with any existing spans. */
++    pos = cover_find(cover, beg);
++    if ((pos > 0 && beg < cover->span[pos - 1].end) ||
++        (pos < cover->num && end > cover->span[pos].beg))
++        return 1;
++
++    /* Check for adjacencies. */
++    prec = pos > 0 && beg == cover->span[pos - 1].end;
++    foll = pos < cover->num && end == cover->span[pos].beg;
++    if (prec && foll) {
++        /* The new span connects the preceding and following spans. Merge the
++           following span into the preceding span, and delete the following
++           span. */
++        cover->span[pos - 1].end = cover->span[pos].end;
++        cover->num--;
++        memmove(cover->span + pos, cover->span + pos + 1,
++                (cover->num - pos) * sizeof(span_t));
++    }
++    else if (prec)
++        /* The new span is adjacent only to the preceding span. Extend the end
++           of the preceding span. */
++        cover->span[pos - 1].end = end;
++    else if (foll)
++        /* The new span is adjacent only to the following span. Extend the
++           beginning of the following span. */
++        cover->span[pos].beg = beg;
++    else {
++        /* The new span has gaps between both the preceding and the following
++           spans. Assure that there is room and insert the span.  */
++        if (cover->num == cover->max) {
++            size_t max = cover->max == 0 ? 16 : cover->max << 1;
++            span_t *span = realloc(cover->span, max * sizeof(span_t));
++            if (span == NULL)
++                return -2;
++            cover->span = span;
++            cover->max = max;
++        }
++        memmove(cover->span + pos + 1, cover->span + pos,
++                (cover->num - pos) * sizeof(span_t));
++        cover->num++;
++        cover->span[pos].beg = beg;
++        cover->span[pos].end = end;
++    }
++    return 0;
++}
+ 
+ 
+ 
+@@ -376,6 +495,29 @@
+     }
+ #endif /* !SFX || SFX_EXDIR */
+ 
++    /* One more: initialize cover structure for bomb detection. Start with a
++       span that covers the central directory though the end of the file. */
++    if (G.cover == NULL) {
++        G.cover = malloc(sizeof(cover_t));
++        if (G.cover == NULL) {
++            Info(slide, 0x401, ((char *)slide,
++              LoadFarString(NotEnoughMemCover)));
++            return PK_MEM;
++        }
++        ((cover_t *)G.cover)->span = NULL;
++        ((cover_t *)G.cover)->max = 0;
++    }
++    ((cover_t *)G.cover)->num = 0;
++    if ((G.extra_bytes != 0 &&
++         cover_add((cover_t *)G.cover, 0, G.extra_bytes) != 0) ||
++        cover_add((cover_t *)G.cover,
++                  G.extra_bytes + G.ecrec.offset_start_central_directory,
++                  G.ziplen) != 0) {
++        Info(slide, 0x401, ((char *)slide,
++          LoadFarString(NotEnoughMemCover)));
++        return PK_MEM;
++    }
++
+ /*---------------------------------------------------------------------------
+     The basic idea of this function is as follows.  Since the central di-
+     rectory lies at the end of the zipfile and the member files lie at the
+@@ -593,7 +735,8 @@
+             if (error > error_in_archive)
+                 error_in_archive = error;
+             /* ...and keep going (unless disk full or user break) */
+-            if (G.disk_full > 1 || error_in_archive == IZ_CTRLC) {
++            if (G.disk_full > 1 || error_in_archive == IZ_CTRLC ||
++                error == PK_BOMB) {
+                 /* clear reached_end to signal premature stop ... */
+                 reached_end = FALSE;
+                 /* ... and cancel scanning the central directory */
+@@ -1062,6 +1205,11 @@
+ 
+         /* seek_zipf(__G__ pInfo->offset);  */
+         request = G.pInfo->offset + G.extra_bytes;
++        if (cover_within((cover_t *)G.cover, request)) {
++            Info(slide, 0x401, ((char *)slide,
++              LoadFarString(OverlappedComponents)));
++            return PK_BOMB;
++        }
+         inbuf_offset = request % INBUFSIZ;
+         bufstart = request - inbuf_offset;
+ 
+@@ -1602,6 +1750,18 @@
+             return IZ_CTRLC;        /* cancel operation by user request */
+         }
+ #endif
++        error = cover_add((cover_t *)G.cover, request,
++                          G.cur_zipfile_bufstart + (G.inptr - G.inbuf));
++        if (error < 0) {
++            Info(slide, 0x401, ((char *)slide,
++              LoadFarString(NotEnoughMemCover)));
++            return PK_MEM;
++        }
++        if (error != 0) {
++            Info(slide, 0x401, ((char *)slide,
++              LoadFarString(OverlappedComponents)));
++            return PK_BOMB;
++        }
+ #ifdef MACOS  /* MacOS is no preemptive OS, thus call event-handling by hand */
+         UserStop();
+ #endif
+@@ -2003,6 +2163,34 @@
+     }
+ 
+     undefer_input(__G);
++
++    if ((G.lrec.general_purpose_bit_flag & 8) != 0) {
++        /* skip over data descriptor (harder than it sounds, due to signature
++         * ambiguity)
++         */
++#       define SIG 0x08074b50
++#       define LOW 0xffffffff
++        uch buf[12];
++        unsigned shy = 12 - readbuf((char *)buf, 12);
++        ulg crc = shy ? 0 : makelong(buf);
++        ulg clen = shy ? 0 : makelong(buf + 4);
++        ulg ulen = shy ? 0 : makelong(buf + 8); /* or high clen if ZIP64 */
++        if (crc == SIG &&                       /* if not SIG, no signature */
++            (G.lrec.crc32 != SIG ||             /* if not SIG, have signature */
++             (clen == SIG &&                    /* if not SIG, no signature */
++              ((G.lrec.csize & LOW) != SIG ||   /* if not SIG, have signature */
++               (ulen == SIG &&                  /* if not SIG, no signature */
++                (G.zip64 ? G.lrec.csize >> 32 : G.lrec.ucsize) != SIG
++                                                /* if not SIG, have signature */
++                )))))
++                   /* skip four more bytes to account for signature */
++                   shy += 4 - readbuf((char *)buf, 4);
++        if (G.zip64)
++            shy += 8 - readbuf((char *)buf, 8); /* skip eight more for ZIP64 */
++        if (shy)
++            error = PK_ERR;
++    }
++
+     return error;
+ 
+ } /* end function extract_or_test_member() */
+--- a/globals.c
++++ b/globals.c
+@@ -181,6 +181,7 @@
+ # if (!defined(NO_TIMESTAMPS))
+     uO.D_flag=1;    /* default to '-D', no restoration of dir timestamps */
+ # endif
++    G.cover = NULL;     /* not allocated yet */
+ #endif
+ 
+     uO.lflag=(-1);
+--- a/globals.h
++++ b/globals.h
+@@ -260,12 +260,15 @@
+     ecdir_rec       ecrec;         /* used in unzip.c, extract.c */
+     z_stat   statbuf;              /* used by main, mapname, check_for_newer */
+ 
++    int zip64;                     /* true if Zip64 info in extra field */
++
+     int      mem_mode;
+     uch      *outbufptr;           /* extract.c static */
+     ulg      outsize;              /* extract.c static */
+     int      reported_backslash;   /* extract.c static */
+     int      disk_full;
+     int      newfile;
++    void     **cover;              /* used in extract.c for bomb detection */
+ 
+     int      didCRlast;            /* fileio static */
+     ulg      numlines;             /* fileio static: number of lines printed */
+--- a/process.c
++++ b/process.c
+@@ -637,6 +637,13 @@
+     }
+ #endif
+ 
++    /* Free the cover span list and the cover structure. */
++    if (G.cover != NULL) {
++        free(*(G.cover));
++        free(G.cover);
++        G.cover = NULL;
++    }
++
+ } /* end function free_G_buffers() */
+ 
+ 
+@@ -1913,6 +1920,8 @@
+ #define Z64FLGS 0xffff
+ #define Z64FLGL 0xffffffff
+ 
++    G.zip64 = FALSE;
++
+     if (ef_len == 0 || ef_buf == NULL)
+         return PK_COOL;
+ 
+@@ -2084,6 +2093,8 @@
+                     (ZCONST char *)(offset + ef_buf), ULen);
+             G.unipath_filename[ULen] = '\0';
+           }
++
++          G.zip64 = TRUE;
+         }
+ 
+         /* Skip this extra field block */
+--- a/unzip.h
++++ b/unzip.h
+@@ -645,6 +645,7 @@
+ #define PK_NOZIP           9   /* zipfile not found */
+ #define PK_PARAM          10   /* bad or illegal parameters specified */
+ #define PK_FIND           11   /* no files found */
++#define PK_BOMB           12   /* likely zip bomb */
+ #define PK_DISK           50   /* disk full */
+ #define PK_EOF            51   /* unexpected EOF */
+ 

--- a/build/unzip/patches/CVE-2019-13232b.patch
+++ b/build/unzip/patches/CVE-2019-13232b.patch
@@ -27,9 +27,10 @@ X-Debian-version: 6.0-24
     This commit depends on a preceding commit: "Fix bug in
     undefer_input() that misplaced the input state."
 
---- a/extract.c
-+++ b/extract.c
-@@ -321,6 +321,125 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/extract.c a/extract.c
+--- a~/extract.c	1970-01-01 00:00:00
++++ a/extract.c	1970-01-01 00:00:00
+@@ -321,6 +321,125 @@ static ZCONST char Far UnsupportedExtraF
    "\nerror:  unsupported extra-field compression type (%u)--skipping\n";
  static ZCONST char Far BadExtraFieldCRC[] =
    "error [%s]:  bad extra-field CRC %08lx (should be %08lx)\n";
@@ -155,7 +156,7 @@ X-Debian-version: 6.0-24
  
  
  
-@@ -376,6 +495,29 @@
+@@ -376,6 +495,29 @@ int extract_or_test_files(__G)    /* ret
      }
  #endif /* !SFX || SFX_EXDIR */
  
@@ -185,7 +186,7 @@ X-Debian-version: 6.0-24
  /*---------------------------------------------------------------------------
      The basic idea of this function is as follows.  Since the central di-
      rectory lies at the end of the zipfile and the member files lie at the
-@@ -593,7 +735,8 @@
+@@ -593,7 +735,8 @@ int extract_or_test_files(__G)    /* ret
              if (error > error_in_archive)
                  error_in_archive = error;
              /* ...and keep going (unless disk full or user break) */
@@ -195,7 +196,7 @@ X-Debian-version: 6.0-24
                  /* clear reached_end to signal premature stop ... */
                  reached_end = FALSE;
                  /* ... and cancel scanning the central directory */
-@@ -1062,6 +1205,11 @@
+@@ -1062,6 +1205,11 @@ static int extract_or_test_entrylist(__G
  
          /* seek_zipf(__G__ pInfo->offset);  */
          request = G.pInfo->offset + G.extra_bytes;
@@ -207,7 +208,7 @@ X-Debian-version: 6.0-24
          inbuf_offset = request % INBUFSIZ;
          bufstart = request - inbuf_offset;
  
-@@ -1602,6 +1750,18 @@
+@@ -1602,6 +1750,18 @@ reprompt:
              return IZ_CTRLC;        /* cancel operation by user request */
          }
  #endif
@@ -226,7 +227,7 @@ X-Debian-version: 6.0-24
  #ifdef MACOS  /* MacOS is no preemptive OS, thus call event-handling by hand */
          UserStop();
  #endif
-@@ -2003,6 +2163,34 @@
+@@ -2003,6 +2163,34 @@ static int extract_or_test_member(__G)
      }
  
      undefer_input(__G);
@@ -261,9 +262,10 @@ X-Debian-version: 6.0-24
      return error;
  
  } /* end function extract_or_test_member() */
---- a/globals.c
-+++ b/globals.c
-@@ -181,6 +181,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/globals.c a/globals.c
+--- a~/globals.c	1970-01-01 00:00:00
++++ a/globals.c	1970-01-01 00:00:00
+@@ -181,6 +181,7 @@ Uz_Globs *globalsCtor()
  # if (!defined(NO_TIMESTAMPS))
      uO.D_flag=1;    /* default to '-D', no restoration of dir timestamps */
  # endif
@@ -271,9 +273,10 @@ X-Debian-version: 6.0-24
  #endif
  
      uO.lflag=(-1);
---- a/globals.h
-+++ b/globals.h
-@@ -260,12 +260,15 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/globals.h a/globals.h
+--- a~/globals.h	1970-01-01 00:00:00
++++ a/globals.h	1970-01-01 00:00:00
+@@ -260,12 +260,15 @@ typedef struct Globals {
      ecdir_rec       ecrec;         /* used in unzip.c, extract.c */
      z_stat   statbuf;              /* used by main, mapname, check_for_newer */
  
@@ -289,9 +292,10 @@ X-Debian-version: 6.0-24
  
      int      didCRlast;            /* fileio static */
      ulg      numlines;             /* fileio static: number of lines printed */
---- a/process.c
-+++ b/process.c
-@@ -637,6 +637,13 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/process.c a/process.c
+--- a~/process.c	1970-01-01 00:00:00
++++ a/process.c	1970-01-01 00:00:00
+@@ -637,6 +637,13 @@ void free_G_buffers(__G)     /* releases
      }
  #endif
  
@@ -305,7 +309,7 @@ X-Debian-version: 6.0-24
  } /* end function free_G_buffers() */
  
  
-@@ -1913,6 +1920,8 @@
+@@ -1900,6 +1907,8 @@ int getZip64Data(__G__ ef_buf, ef_len)
  #define Z64FLGS 0xffff
  #define Z64FLGL 0xffffffff
  
@@ -314,7 +318,7 @@ X-Debian-version: 6.0-24
      if (ef_len == 0 || ef_buf == NULL)
          return PK_COOL;
  
-@@ -2084,6 +2093,8 @@
+@@ -2071,6 +2080,8 @@ int getUnicodeData(__G__ ef_buf, ef_len)
                      (ZCONST char *)(offset + ef_buf), ULen);
              G.unipath_filename[ULen] = '\0';
            }
@@ -323,9 +327,10 @@ X-Debian-version: 6.0-24
          }
  
          /* Skip this extra field block */
---- a/unzip.h
-+++ b/unzip.h
-@@ -645,6 +645,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/unzip.h a/unzip.h
+--- a~/unzip.h	1970-01-01 00:00:00
++++ a/unzip.h	1970-01-01 00:00:00
+@@ -645,6 +645,7 @@ typedef struct _Uzp_cdir_Rec {
  #define PK_NOZIP           9   /* zipfile not found */
  #define PK_PARAM          10   /* bad or illegal parameters specified */
  #define PK_FIND           11   /* no files found */

--- a/build/unzip/patches/CVE-2019-13232c.patch
+++ b/build/unzip/patches/CVE-2019-13232c.patch
@@ -1,0 +1,103 @@
+From: Mark Adler <madler@alumni.caltech.edu>
+Subject: Do not raise a zip bomb alert for a misplaced central directory.
+Origin: https://github.com/madler/unzip/commit/6d351831be705cc26d897db44f878a978f4138fc
+Bug-Debian: https://bugs.debian.org/932404
+X-Debian-version: 6.0-25
+
+    Do not raise a zip bomb alert for a misplaced central directory.
+    
+    There is a zip-like file in the Firefox distribution, omni.ja,
+    which is a zip container with the central directory placed at the
+    start of the file instead of after the local entries as required
+    by the zip standard. This commit marks the actual location of the
+    central directory, as well as the end of central directory records,
+    as disallowed locations. This now permits such containers to not
+    raise a zip bomb alert, where in fact there are no overlaps.
+
+--- a/extract.c
++++ b/extract.c
+@@ -495,8 +495,11 @@
+     }
+ #endif /* !SFX || SFX_EXDIR */
+ 
+-    /* One more: initialize cover structure for bomb detection. Start with a
+-       span that covers the central directory though the end of the file. */
++    /* One more: initialize cover structure for bomb detection. Start with
++       spans that cover any extra bytes at the start, the central directory,
++       the end of central directory record (including the Zip64 end of central
++       directory locator, if present), and the Zip64 end of central directory
++       record, if present. */
+     if (G.cover == NULL) {
+         G.cover = malloc(sizeof(cover_t));
+         if (G.cover == NULL) {
+@@ -508,15 +511,25 @@
+         ((cover_t *)G.cover)->max = 0;
+     }
+     ((cover_t *)G.cover)->num = 0;
+-    if ((G.extra_bytes != 0 &&
+-         cover_add((cover_t *)G.cover, 0, G.extra_bytes) != 0) ||
+-        cover_add((cover_t *)G.cover,
++    if (cover_add((cover_t *)G.cover,
+                   G.extra_bytes + G.ecrec.offset_start_central_directory,
+-                  G.ziplen) != 0) {
++                  G.extra_bytes + G.ecrec.offset_start_central_directory +
++                  G.ecrec.size_central_directory) != 0) {
+         Info(slide, 0x401, ((char *)slide,
+           LoadFarString(NotEnoughMemCover)));
+         return PK_MEM;
+     }
++    if ((G.extra_bytes != 0 &&
++         cover_add((cover_t *)G.cover, 0, G.extra_bytes) != 0) ||
++        (G.ecrec.have_ecr64 &&
++         cover_add((cover_t *)G.cover, G.ecrec.ec64_start,
++                   G.ecrec.ec64_end) != 0) ||
++        cover_add((cover_t *)G.cover, G.ecrec.ec_start,
++                  G.ecrec.ec_end) != 0) {
++        Info(slide, 0x401, ((char *)slide,
++          LoadFarString(OverlappedComponents)));
++        return PK_BOMB;
++    }
+ 
+ /*---------------------------------------------------------------------------
+     The basic idea of this function is as follows.  Since the central di-
+--- a/process.c
++++ b/process.c
+@@ -1408,6 +1408,10 @@
+ 
+     /* Now, we are (almost) sure that we have a Zip64 archive. */
+     G.ecrec.have_ecr64 = 1;
++    G.ecrec.ec_start -= ECLOC64_SIZE+4;
++    G.ecrec.ec64_start = ecrec64_start_offset;
++    G.ecrec.ec64_end = ecrec64_start_offset +
++                       12 + makeint64(&byterec[ECREC64_LENGTH]);
+ 
+     /* Update the "end-of-central-dir offset" for later checks. */
+     G.real_ecrec_offset = ecrec64_start_offset;
+@@ -1542,6 +1546,8 @@
+       makelong(&byterec[OFFSET_START_CENTRAL_DIRECTORY]);
+     G.ecrec.zipfile_comment_length =
+       makeword(&byterec[ZIPFILE_COMMENT_LENGTH]);
++    G.ecrec.ec_start = G.real_ecrec_offset;
++    G.ecrec.ec_end = G.ecrec.ec_start + 22 + G.ecrec.zipfile_comment_length;
+ 
+     /* Now, we have to read the archive comment, BEFORE the file pointer
+        is moved away backwards to seek for a Zip64 ECLOC64 structure.
+--- a/unzpriv.h
++++ b/unzpriv.h
+@@ -2185,6 +2185,16 @@
+        int have_ecr64;                  /* valid Zip64 ecdir-record exists */
+        int is_zip64_archive;            /* Zip64 ecdir-record is mandatory */
+        ush zipfile_comment_length;
++       zusz_t ec_start, ec_end;         /* offsets of start and end of the
++                                           end of central directory record,
++                                           including if present the Zip64
++                                           end of central directory locator,
++                                           which immediately precedes the
++                                           end of central directory record */
++       zusz_t ec64_start, ec64_end;     /* if have_ecr64 is true, then these
++                                           are the offsets of the start and
++                                           end of the Zip64 end of central
++                                           directory record */
+    } ecdir_rec;
+ 
+ 

--- a/build/unzip/patches/CVE-2019-13232c.patch
+++ b/build/unzip/patches/CVE-2019-13232c.patch
@@ -14,9 +14,10 @@ X-Debian-version: 6.0-25
     as disallowed locations. This now permits such containers to not
     raise a zip bomb alert, where in fact there are no overlaps.
 
---- a/extract.c
-+++ b/extract.c
-@@ -495,8 +495,11 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/extract.c a/extract.c
+--- a~/extract.c	1970-01-01 00:00:00
++++ a/extract.c	1970-01-01 00:00:00
+@@ -495,8 +495,11 @@ int extract_or_test_files(__G)    /* ret
      }
  #endif /* !SFX || SFX_EXDIR */
  
@@ -30,7 +31,7 @@ X-Debian-version: 6.0-25
      if (G.cover == NULL) {
          G.cover = malloc(sizeof(cover_t));
          if (G.cover == NULL) {
-@@ -508,15 +511,25 @@
+@@ -508,15 +511,25 @@ int extract_or_test_files(__G)    /* ret
          ((cover_t *)G.cover)->max = 0;
      }
      ((cover_t *)G.cover)->num = 0;
@@ -60,9 +61,10 @@ X-Debian-version: 6.0-25
  
  /*---------------------------------------------------------------------------
      The basic idea of this function is as follows.  Since the central di-
---- a/process.c
-+++ b/process.c
-@@ -1408,6 +1408,10 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/process.c a/process.c
+--- a~/process.c	1970-01-01 00:00:00
++++ a/process.c	1970-01-01 00:00:00
+@@ -1408,6 +1408,10 @@ static int find_ecrec64(__G__ searchlen)
  
      /* Now, we are (almost) sure that we have a Zip64 archive. */
      G.ecrec.have_ecr64 = 1;
@@ -73,7 +75,7 @@ X-Debian-version: 6.0-25
  
      /* Update the "end-of-central-dir offset" for later checks. */
      G.real_ecrec_offset = ecrec64_start_offset;
-@@ -1542,6 +1546,8 @@
+@@ -1542,6 +1546,8 @@ static int find_ecrec(__G__ searchlen)
        makelong(&byterec[OFFSET_START_CENTRAL_DIRECTORY]);
      G.ecrec.zipfile_comment_length =
        makeword(&byterec[ZIPFILE_COMMENT_LENGTH]);
@@ -82,9 +84,10 @@ X-Debian-version: 6.0-25
  
      /* Now, we have to read the archive comment, BEFORE the file pointer
         is moved away backwards to seek for a Zip64 ECLOC64 structure.
---- a/unzpriv.h
-+++ b/unzpriv.h
-@@ -2185,6 +2185,16 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/unzpriv.h a/unzpriv.h
+--- a~/unzpriv.h	1970-01-01 00:00:00
++++ a/unzpriv.h	1970-01-01 00:00:00
+@@ -2185,6 +2185,16 @@ typedef struct VMStimbuf {
         int have_ecr64;                  /* valid Zip64 ecdir-record exists */
         int is_zip64_archive;            /* Zip64 ecdir-record is mandatory */
         ush zipfile_comment_length;

--- a/build/unzip/patches/CVE-2019-13232d.patch
+++ b/build/unzip/patches/CVE-2019-13232d.patch
@@ -1,0 +1,23 @@
+From: Mark Adler <madler@alumni.caltech.edu>
+Subject: Fix bug in UZbunzip2() that incorrectly updated G.incnt
+Origin: https://github.com/madler/unzip/commit/5e2efcd633a4a1fb95a129a75508e7d769e767be
+Bug-Debian: https://bugs.debian.org/963996
+X-Debian-version: 6.0-26
+
+    Fix bug in UZbunzip2() that incorrectly updated G.incnt.
+    
+    The update assumed a full buffer, which is not always full. This
+    could result in a false overlapped element detection when a small
+    bzip2-compressed file was unzipped. This commit remedies that.
+
+--- a/extract.c
++++ b/extract.c
+@@ -3052,7 +3052,7 @@
+ #endif
+ 
+     G.inptr = (uch *)bstrm.next_in;
+-    G.incnt = (G.inbuf + INBUFSIZ) - G.inptr;  /* reset for other routines */
++    G.incnt -= G.inptr - G.inbuf;       /* reset for other routines */
+ 
+ uzbunzip_cleanup_exit:
+     err = BZ2_bzDecompressEnd(&bstrm);

--- a/build/unzip/patches/CVE-2019-13232d.patch
+++ b/build/unzip/patches/CVE-2019-13232d.patch
@@ -10,9 +10,10 @@ X-Debian-version: 6.0-26
     could result in a false overlapped element detection when a small
     bzip2-compressed file was unzipped. This commit remedies that.
 
---- a/extract.c
-+++ b/extract.c
-@@ -3052,7 +3052,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/extract.c a/extract.c
+--- a~/extract.c	1970-01-01 00:00:00
++++ a/extract.c	1970-01-01 00:00:00
+@@ -3051,7 +3051,7 @@ __GDEF
  #endif
  
      G.inptr = (uch *)bstrm.next_in;

--- a/build/unzip/patches/CVE-2019-13232e.patch
+++ b/build/unzip/patches/CVE-2019-13232e.patch
@@ -1,0 +1,23 @@
+From: Mark Adler <madler@alumni.caltech.edu>
+Subject: Fix bug in UZinflate() that incorrectly updated G.incnt.
+Origin: https://github.com/madler/unzip/commit/5c572555cf5d80309a07c30cf7a54b2501493720
+X-Debian-version: 6.0-26
+
+    Fix bug in UZinflate() that incorrectly updated G.incnt.
+    
+    The update assumed a full buffer, which is not always full. This
+    could result in a false overlapped element detection when a small
+    deflate-compressed file was unzipped using an old zlib. This
+    commit remedies that.
+
+--- a/inflate.c
++++ b/inflate.c
+@@ -700,7 +700,7 @@
+       G.dstrm.total_out));
+ 
+     G.inptr = (uch *)G.dstrm.next_in;
+-    G.incnt = (G.inbuf + INBUFSIZ) - G.inptr;  /* reset for other routines */
++    G.incnt -= G.inptr - G.inbuf;       /* reset for other routines */
+ 
+ uzinflate_cleanup_exit:
+     err = inflateReset(&G.dstrm);

--- a/build/unzip/patches/CVE-2019-13232e.patch
+++ b/build/unzip/patches/CVE-2019-13232e.patch
@@ -10,9 +10,10 @@ X-Debian-version: 6.0-26
     deflate-compressed file was unzipped using an old zlib. This
     commit remedies that.
 
---- a/inflate.c
-+++ b/inflate.c
-@@ -700,7 +700,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/inflate.c a/inflate.c
+--- a~/inflate.c	1970-01-01 00:00:00
++++ a/inflate.c	1970-01-01 00:00:00
+@@ -700,7 +700,7 @@ int UZinflate(__G__ is_defl64)
        G.dstrm.total_out));
  
      G.inptr = (uch *)G.dstrm.next_in;

--- a/build/unzip/patches/CVE-2021-4217.patch
+++ b/build/unzip/patches/CVE-2021-4217.patch
@@ -1,0 +1,21 @@
+This is re-implementation of
+https://launchpadlibrarian.net/580782282/0001-Fix-null-pointer-dereference-and-use-of-uninitialized-data.patch
+into unzip 6.1beta c25
+As can be seen in fileio.c:3326 patch is already implemented here but not in process.c
+
+I will try to ask Steven Schweda (maintainer) why it is so.
+
+--- a/process.c	2022-02-28 21:31:13.665727140 +0000
++++ b/process.c	2022-02-28 21:32:11.636401015 +0000
+@@ -2626,6 +2626,11 @@
+           G.unipath_checksum = makelong(offset + ef_buf);
+           offset += 4;
+ 
++          if (!G.filename_full) {
++            /* Check if we have a unicode extra section but no filename set */
++            return PK_ERR;
++          }
++
+           /*
+            * Compute 32-bit crc
+            */

--- a/build/unzip/patches/CVE-2021-4217.patch
+++ b/build/unzip/patches/CVE-2021-4217.patch
@@ -5,9 +5,10 @@ As can be seen in fileio.c:3326 patch is already implemented here but not in pro
 
 I will try to ask Steven Schweda (maintainer) why it is so.
 
---- a/process.c	2022-02-28 21:31:13.665727140 +0000
-+++ b/process.c	2022-02-28 21:32:11.636401015 +0000
-@@ -2626,6 +2626,11 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/process.c a/process.c
+--- a~/process.c	1970-01-01 00:00:00
++++ a/process.c	1970-01-01 00:00:00
+@@ -2051,6 +2051,11 @@ int getUnicodeData(__G__ ef_buf, ef_len)
            G.unipath_checksum = makelong(offset + ef_buf);
            offset += 4;
  

--- a/build/unzip/patches/CVE-2022-0529-0530.patch
+++ b/build/unzip/patches/CVE-2022-0529-0530.patch
@@ -1,0 +1,173 @@
+From: Steven M. Schweda <sms@antinode.info>
+Subject: Fix for CVE-2022-0529 and CVE-2022-0530
+Bug-Debian: https://bugs.debian.org/1010355
+X-Debian-version: 6.0-27
+
+--- a/fileio.c
++++ b/fileio.c
+@@ -171,8 +171,10 @@
+ static ZCONST char Far FilenameTooLongTrunc[] =
+   "warning:  filename too long--truncating.\n";
+ #ifdef UNICODE_SUPPORT
++   static ZCONST char Far UFilenameCorrupt[] =
++     "error: Unicode filename corrupt.\n";
+    static ZCONST char Far UFilenameTooLongTrunc[] =
+-     "warning:  Converted unicode filename too long--truncating.\n";
++     "warning:  Converted Unicode filename too long--truncating.\n";
+ #endif
+ static ZCONST char Far ExtraFieldTooLong[] =
+   "warning:  extra field too long (%d).  Ignoring...\n";
+@@ -2361,16 +2363,30 @@
+                   /* convert UTF-8 to local character set */
+                   fn = utf8_to_local_string(G.unipath_filename,
+                                             G.unicode_escape_all);
+-                  /* make sure filename is short enough */
+-                  if (strlen(fn) >= FILNAMSIZ) {
+-                    fn[FILNAMSIZ - 1] = '\0';
++
++                  /* 2022-07-22 SMS, et al.  CVE-2022-0530
++                   * Detect conversion failure, emit message.
++                   * Continue with unconverted name.
++                   */
++                  if (fn == NULL)
++                  {
+                     Info(slide, 0x401, ((char *)slide,
+-                      LoadFarString(UFilenameTooLongTrunc)));
+-                    error = PK_WARN;
++                     LoadFarString(UFilenameCorrupt)));
++                    error = PK_ERR;
++                  }
++                  else
++                  {
++                    /* make sure filename is short enough */
++                    if (strlen(fn) >= FILNAMSIZ) {
++                      fn[FILNAMSIZ - 1] = '\0';
++                      Info(slide, 0x401, ((char *)slide,
++                        LoadFarString(UFilenameTooLongTrunc)));
++                      error = PK_WARN;
++                    }
++                    /* replace filename with converted UTF-8 */
++                    strcpy(G.filename, fn);
++                    free(fn);
+                   }
+-                  /* replace filename with converted UTF-8 */
+-                  strcpy(G.filename, fn);
+-                  free(fn);
+                 }
+ # endif /* UNICODE_WCHAR */
+                 if (G.unipath_filename != G.filename_full)
+--- a/process.c
++++ b/process.c
+@@ -222,6 +222,8 @@
+      "\nwarning:  Unicode Path version > 1\n";
+    static ZCONST char Far UnicodeMismatchError[] =
+      "\nwarning:  Unicode Path checksum invalid\n";
++   static ZCONST char Far UFilenameTooLongTrunc[] =
++     "warning:  filename too long (P1) -- truncating.\n";
+ #endif
+ 
+ 
+@@ -1915,7 +1917,7 @@
+     Sets both local header and central header fields.  Not terribly clever,
+     but it means that this procedure is only called in one place.
+ 
+-    2014-12-05 SMS.
++    2014-12-05 SMS.  (oCERT.org report.)  CVE-2014-8141.
+     Added checks to ensure that enough data are available before calling
+     makeint64() or makelong().  Replaced various sizeof() values with
+     simple ("4" or "8") constants.  (The Zip64 structures do not depend
+@@ -1947,9 +1949,10 @@
+               ef_len - EB_HEADSIZE));
+             break;
+         }
++
+         if (eb_id == EF_PKSZ64)
+         {
+-          int offset = EB_HEADSIZE;
++          unsigned offset = EB_HEADSIZE;
+ 
+           if ((G.crec.ucsize == Z64FLGL) || (G.lrec.ucsize == Z64FLGL))
+           {
+@@ -2046,7 +2049,7 @@
+         }
+         if (eb_id == EF_UNIPATH) {
+ 
+-          int offset = EB_HEADSIZE;
++          unsigned offset = EB_HEADSIZE;
+           ush ULen = eb_len - 5;
+           ulg chksum = CRCVAL_INITIAL;
+ 
+@@ -2504,16 +2507,17 @@
+   int state_dependent;
+   int wsize = 0;
+   int max_bytes = MB_CUR_MAX;
+-  char buf[9];
++  char buf[ MB_CUR_MAX+ 1];             /* ("+1" not really needed?) */
+   char *buffer = NULL;
+   char *local_string = NULL;
++  size_t buffer_size;                   /* CVE-2022-0529 */
+ 
+   for (wsize = 0; wide_string[wsize]; wsize++) ;
+ 
+   if (max_bytes < MAX_ESCAPE_BYTES)
+     max_bytes = MAX_ESCAPE_BYTES;
+-
+-  if ((buffer = (char *)malloc(wsize * max_bytes + 1)) == NULL) {
++  buffer_size = wsize * max_bytes + 1;          /* Reused below. */
++  if ((buffer = (char *)malloc( buffer_size)) == NULL) {
+     return NULL;
+   }
+ 
+@@ -2551,8 +2555,28 @@
+     } else {
+       /* no MB for this wide */
+         /* use escape for wide character */
+-        char *escape_string = wide_to_escape_string(wide_string[i]);
+-        strcat(buffer, escape_string);
++        size_t buffer_len;
++        size_t escape_string_len;
++        char *escape_string;
++        int err_msg = 0;
++
++        escape_string = wide_to_escape_string(wide_string[i]);
++        buffer_len = strlen( buffer);
++        escape_string_len = strlen( escape_string);
++
++        /* Append escape string, as space allows. */
++        /* 2022-07-18 SMS, et al.  CVE-2022-0529 */
++        if (escape_string_len > buffer_size- buffer_len- 1)
++        {
++            escape_string_len = buffer_size- buffer_len- 1;
++            if (err_msg == 0)
++            {
++                err_msg = 1;
++                Info(slide, 0x401, ((char *)slide,
++                 LoadFarString( UFilenameTooLongTrunc)));
++            }
++        }
++        strncat( buffer, escape_string, escape_string_len);
+         free(escape_string);
+     }
+   }
+@@ -2604,9 +2628,18 @@
+   ZCONST char *utf8_string;
+   int escape_all;
+ {
+-  zwchar *wide = utf8_to_wide_string(utf8_string);
+-  char *loc = wide_to_local_string(wide, escape_all);
+-  free(wide);
++  zwchar *wide;
++  char *loc = NULL;
++
++  wide = utf8_to_wide_string( utf8_string);
++
++  /* 2022-07-25 SMS, et al.  CVE-2022-0530 */
++  if (wide != NULL)
++  {
++    loc = wide_to_local_string( wide, escape_all);
++    free( wide);
++  }
++
+   return loc;
+ }
+ 

--- a/build/unzip/patches/CVE-2022-0529-0530.patch
+++ b/build/unzip/patches/CVE-2022-0529-0530.patch
@@ -3,9 +3,10 @@ Subject: Fix for CVE-2022-0529 and CVE-2022-0530
 Bug-Debian: https://bugs.debian.org/1010355
 X-Debian-version: 6.0-27
 
---- a/fileio.c
-+++ b/fileio.c
-@@ -171,8 +171,10 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/fileio.c a/fileio.c
+--- a~/fileio.c	1970-01-01 00:00:00
++++ a/fileio.c	1970-01-01 00:00:00
+@@ -171,8 +171,10 @@ static ZCONST char Far ReadError[] = "er
  static ZCONST char Far FilenameTooLongTrunc[] =
    "warning:  filename too long--truncating.\n";
  #ifdef UNICODE_SUPPORT
@@ -17,13 +18,10 @@ X-Debian-version: 6.0-27
  #endif
  static ZCONST char Far ExtraFieldTooLong[] =
    "warning:  extra field too long (%d).  Ignoring...\n";
-@@ -2361,16 +2363,30 @@
+@@ -2354,6 +2356,19 @@ int do_string(__G__ length, option)   /*
                    /* convert UTF-8 to local character set */
                    fn = utf8_to_local_string(G.unipath_filename,
                                              G.unicode_escape_all);
--                  /* make sure filename is short enough */
--                  if (strlen(fn) >= FILNAMSIZ) {
--                    fn[FILNAMSIZ - 1] = '\0';
 +
 +                  /* 2022-07-22 SMS, et al.  CVE-2022-0530
 +                   * Detect conversion failure, emit message.
@@ -31,34 +29,27 @@ X-Debian-version: 6.0-27
 +                   */
 +                  if (fn == NULL)
 +                  {
-                     Info(slide, 0x401, ((char *)slide,
--                      LoadFarString(UFilenameTooLongTrunc)));
--                    error = PK_WARN;
++                    Info(slide, 0x401, ((char *)slide,
 +                     LoadFarString(UFilenameCorrupt)));
 +                    error = PK_ERR;
 +                  }
 +                  else
 +                  {
-+                    /* make sure filename is short enough */
-+                    if (strlen(fn) >= FILNAMSIZ) {
-+                      fn[FILNAMSIZ - 1] = '\0';
-+                      Info(slide, 0x401, ((char *)slide,
-+                        LoadFarString(UFilenameTooLongTrunc)));
-+                      error = PK_WARN;
-+                    }
-+                    /* replace filename with converted UTF-8 */
-+                    strcpy(G.filename, fn);
-+                    free(fn);
-                   }
--                  /* replace filename with converted UTF-8 */
--                  strcpy(G.filename, fn);
--                  free(fn);
+                   /* make sure filename is short enough */
+                   if (strlen(fn) >= FILNAMSIZ) {
+                     fn[FILNAMSIZ - 1] = '\0';
+@@ -2365,6 +2380,7 @@ int do_string(__G__ length, option)   /*
+                   strcpy(G.filename, fn);
+                   free(fn);
                  }
++                }
  # endif /* UNICODE_WCHAR */
                  if (G.unipath_filename != G.filename_full)
---- a/process.c
-+++ b/process.c
-@@ -222,6 +222,8 @@
+                   free(G.unipath_filename);
+diff -wpruN --no-dereference '--exclude=*.orig' a~/process.c a/process.c
+--- a~/process.c	1970-01-01 00:00:00
++++ a/process.c	1970-01-01 00:00:00
+@@ -222,6 +222,8 @@ static ZCONST char Far ZipfileCommTrunc1
       "\nwarning:  Unicode Path version > 1\n";
     static ZCONST char Far UnicodeMismatchError[] =
       "\nwarning:  Unicode Path checksum invalid\n";
@@ -67,7 +58,7 @@ X-Debian-version: 6.0-27
  #endif
  
  
-@@ -1915,7 +1917,7 @@
+@@ -1902,7 +1904,7 @@ int getZip64Data(__G__ ef_buf, ef_len)
      Sets both local header and central header fields.  Not terribly clever,
      but it means that this procedure is only called in one place.
  
@@ -76,7 +67,7 @@ X-Debian-version: 6.0-27
      Added checks to ensure that enough data are available before calling
      makeint64() or makelong().  Replaced various sizeof() values with
      simple ("4" or "8") constants.  (The Zip64 structures do not depend
-@@ -1947,9 +1949,10 @@
+@@ -1934,9 +1936,10 @@ int getZip64Data(__G__ ef_buf, ef_len)
                ef_len - EB_HEADSIZE));
              break;
          }
@@ -88,7 +79,7 @@ X-Debian-version: 6.0-27
  
            if ((G.crec.ucsize == Z64FLGL) || (G.lrec.ucsize == Z64FLGL))
            {
-@@ -2046,7 +2049,7 @@
+@@ -2033,7 +2036,7 @@ int getUnicodeData(__G__ ef_buf, ef_len)
          }
          if (eb_id == EF_UNIPATH) {
  
@@ -97,7 +88,7 @@ X-Debian-version: 6.0-27
            ush ULen = eb_len - 5;
            ulg chksum = CRCVAL_INITIAL;
  
-@@ -2504,16 +2507,17 @@
+@@ -2496,16 +2499,17 @@ char *wide_to_local_string(wide_string,
    int state_dependent;
    int wsize = 0;
    int max_bytes = MB_CUR_MAX;
@@ -118,7 +109,7 @@ X-Debian-version: 6.0-27
      return NULL;
    }
  
-@@ -2551,8 +2555,28 @@
+@@ -2543,8 +2547,28 @@ char *wide_to_local_string(wide_string,
      } else {
        /* no MB for this wide */
          /* use escape for wide character */
@@ -149,13 +140,12 @@ X-Debian-version: 6.0-27
          free(escape_string);
      }
    }
-@@ -2604,9 +2628,18 @@
+@@ -2596,9 +2620,18 @@ char *utf8_to_local_string(utf8_string,
    ZCONST char *utf8_string;
    int escape_all;
  {
 -  zwchar *wide = utf8_to_wide_string(utf8_string);
 -  char *loc = wide_to_local_string(wide, escape_all);
--  free(wide);
 +  zwchar *wide;
 +  char *loc = NULL;
 +
@@ -165,7 +155,7 @@ X-Debian-version: 6.0-27
 +  if (wide != NULL)
 +  {
 +    loc = wide_to_local_string( wide, escape_all);
-+    free( wide);
+   free(wide);
 +  }
 +
    return loc;

--- a/build/unzip/patches/configure.patch
+++ b/build/unzip/patches/configure.patch
@@ -1,6 +1,7 @@
---- a/unix/configure~	2024-01-23 18:53:07.146124861 +0000
-+++ a/unix/configure	2024-01-23 18:53:51.665682899 +0000
-@@ -588,9 +588,9 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/unix/configure a/unix/configure
+--- a~/unix/configure	1970-01-01 00:00:00
++++ a/unix/configure	1970-01-01 00:00:00
+@@ -588,9 +588,9 @@ rm -f a.out conftest.c conftest.o confte
  # bzip2
  
  echo "Check bzip2 support"

--- a/build/unzip/patches/configure.patch
+++ b/build/unzip/patches/configure.patch
@@ -1,0 +1,14 @@
+--- a/unix/configure~	2024-01-23 18:53:07.146124861 +0000
++++ a/unix/configure	2024-01-23 18:53:51.665682899 +0000
+@@ -588,9 +588,9 @@
+ # bzip2
+ 
+ echo "Check bzip2 support"
+-D_USE_BZ2=""
++D_USE_BZ2="-DUSE_BZIP2"
+ LIBBZ2=""
+-L_BZ2=""
++L_BZ2="-lbz2"
+ CC_BZ="${CC}"
+ 
+ if test -n "${IZ_BZIP2}" -a "${IZ_BZIP2}" != "bzip2" ; then

--- a/build/unzip/patches/fileio-big-files.patch
+++ b/build/unzip/patches/fileio-big-files.patch
@@ -1,0 +1,15 @@
+From: "Steven M. Schweda" <sms@antinode.info>
+Subject: Fix lame code in fileio.c
+Bug-Debian: https://bugs.debian.org/929502
+X-Debian-version: 6.0-23
+
+--- a/fileio.c
++++ b/fileio.c
+@@ -2477,6 +2477,7 @@
+      */
+     return (((zusz_t)sig[7]) << 56)
+         + (((zusz_t)sig[6]) << 48)
++        + (((zusz_t)sig[5]) << 40)
+         + (((zusz_t)sig[4]) << 32)
+         + (zusz_t)((((ulg)sig[3]) << 24)
+                  + (((ulg)sig[2]) << 16)

--- a/build/unzip/patches/fileio-big-files.patch
+++ b/build/unzip/patches/fileio-big-files.patch
@@ -3,9 +3,10 @@ Subject: Fix lame code in fileio.c
 Bug-Debian: https://bugs.debian.org/929502
 X-Debian-version: 6.0-23
 
---- a/fileio.c
-+++ b/fileio.c
-@@ -2477,6 +2477,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/fileio.c a/fileio.c
+--- a~/fileio.c	1970-01-01 00:00:00
++++ a/fileio.c	1970-01-01 00:00:00
+@@ -2470,6 +2470,7 @@ zusz_t makeint64(sig)
       */
      return (((zusz_t)sig[7]) << 56)
          + (((zusz_t)sig[6]) << 48)

--- a/build/unzip/patches/integer-underflow-csiz_decrypted.patch
+++ b/build/unzip/patches/integer-underflow-csiz_decrypted.patch
@@ -3,7 +3,7 @@ From: Kamil Dudka <kdudka@redhat.com>
 Date: Tue, 22 Sep 2015 18:52:23 +0200
 Subject: [PATCH] extract: prevent unsigned overflow on invalid input
 
-diff -wpruN '--exclude=*.orig' a~/extract.c a/extract.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/extract.c a/extract.c
 --- a~/extract.c	1970-01-01 00:00:00
 +++ a/extract.c	1970-01-01 00:00:00
 @@ -1257,8 +1257,17 @@ static int extract_or_test_entrylist(__G

--- a/build/unzip/patches/nostrip.patch
+++ b/build/unzip/patches/nostrip.patch
@@ -1,4 +1,4 @@
-diff -wpruN '--exclude=*.orig' a~/unix/Makefile a/unix/Makefile
+diff -wpruN --no-dereference '--exclude=*.orig' a~/unix/Makefile a/unix/Makefile
 --- a~/unix/Makefile	1970-01-01 00:00:00
 +++ a/unix/Makefile	1970-01-01 00:00:00
 @@ -52,7 +52,7 @@ CF_NOOPT = -I. -I$(IZ_BZIP2) -DUNIX $(LO
@@ -19,7 +19,7 @@ diff -wpruN '--exclude=*.orig' a~/unix/Makefile a/unix/Makefile
  E =
  O = .o
  M = unix
-diff -wpruN '--exclude=*.orig' a~/unix/configure a/unix/configure
+diff -wpruN --no-dereference '--exclude=*.orig' a~/unix/configure a/unix/configure
 --- a~/unix/configure	1970-01-01 00:00:00
 +++ a/unix/configure	1970-01-01 00:00:00
 @@ -17,7 +17,7 @@ CFLAGSR=${CFLAGS}

--- a/build/unzip/patches/series
+++ b/build/unzip/patches/series
@@ -1,4 +1,6 @@
+configure.patch
 unix_Makefile.patch
+nostrip.patch
 CVE-2014-8139-crc-overflow.patch
 CVE-2014-8140-test-compr-eb.patch
 CVE-2014-8141-getzip64data.patch
@@ -9,4 +11,11 @@ CVE-2015-7697-infinite-loop.patch
 integer-underflow-csiz_decrypted.patch
 CVE-2016-9844-zipinfo-buffer-overflow.patch
 CVE-2018-1000035-overflow-password-protect.patch
-nostrip.patch
+fileio-big-files.patch
+CVE-2019-13232a.patch
+CVE-2019-13232b.patch
+CVE-2019-13232c.patch
+CVE-2019-13232d.patch
+CVE-2019-13232e.patch
+CVE-2021-4217.patch
+CVE-2022-0529-0530.patch

--- a/build/unzip/patches/unix_Makefile.patch
+++ b/build/unzip/patches/unix_Makefile.patch
@@ -1,4 +1,4 @@
-diff -wpruN '--exclude=*.orig' a~/unix/Makefile a/unix/Makefile
+diff -wpruN --no-dereference '--exclude=*.orig' a~/unix/Makefile a/unix/Makefile
 --- a~/unix/Makefile	1970-01-01 00:00:00
 +++ a/unix/Makefile	1970-01-01 00:00:00
 @@ -121,9 +121,9 @@ INSTALL_PROGRAM = $(INSTALL)


### PR DESCRIPTION
This imports several `unzip` fixes from upstream - https://github.com/omniosorg/omnios-build/pull/3449

```
build:omnios:unzip% ./build/unzip/tmp/build/unzip -t /tmp/build-gimlet-b-lab-image-default.zip
Archive:  /tmp/build-gimlet-b-lab-image-default.zip
hubris build archive v8
    testing: README.TXT               OK
    testing: git-rev                  OK
    testing: image-name               OK
    testing: app.toml                 OK
    testing: chip.toml                OK
    testing: memory.toml              OK
    testing: elf/task/jefe            OK
    testing: elf/task/net             OK
    testing: elf/task/sys             OK
    testing: elf/task/spi2_driver     OK
    testing: elf/task/i2c_driver      OK
    testing: elf/task/spd             OK
    testing: elf/task/packrat         OK
    testing: elf/task/thermal         OK
    testing: elf/task/power           OK
    testing: elf/task/hiffy           OK
    testing: elf/task/gimlet_seq      OK
    testing: elf/task/hash_driver     OK
    testing: elf/task/hf              OK
    testing: elf/task/update_server   OK
    testing: elf/task/sensor          OK
    testing: elf/task/host_sp_comms   OK
    testing: elf/task/udpecho         OK
    testing: elf/task/udpbroadcast    OK
    testing: elf/task/control_plane_agent   OK
    testing: elf/task/sprot           OK
    testing: elf/task/validate        OK
    testing: elf/task/vpd             OK
    testing: elf/task/user_leds       OK
    testing: elf/task/dump_agent      OK
    testing: elf/task/sbrmi           OK
    testing: elf/task/idle            OK
    testing: elf/task/udprpc          OK
    testing: elf/kernel               OK
    testing: img/flash.ron            OK
    testing: debug/script.gdb         OK
    testing: debug/openocd.cfg        OK
    testing: debug/openocd.gdb        OK
    testing: task/gimlet_seq/gimlet-regs-b.json   OK
    testing: img/final.bin            OK
    testing: img/final.elf            OK
    testing: img/final.fwid           OK
No errors detected in compressed data of /tmp/build-gimlet-b-lab-image-default.zip.
```

