### PR TITLE
openssl - update from 3.0.12 to 3.0.13

### DIFF
--- a/build/openssl/build-3.sh
+++ b/build/openssl/build-3.sh
@@ -19,7 +19,7 @@
 . common.sh
 
 PROG=openssl
-VER=3.0.12
+VER=3.0.13
 PKG=library/security/openssl-3
 SUMMARY="Cryptography and SSL/TLS Toolkit"
 DESC="A toolkit for Secure Sockets Layer and Transport Layer protocols "

--- a/build/openssl/testsuite-3.log
+++ b/build/openssl/testsuite-3.log
@@ -42,6 +42,8 @@ Result: NOTESTS
 03-test_ui.t ....................... ok
 04-test_asn1_decode.t .............. ok
 04-test_asn1_encode.t .............. ok
+04-test_asn1_parse.t ............... ok
+04-test_asn1_stable_parse.t ........ ok
 04-test_asn1_string_table.t ........ ok
 04-test_bio_callback.t ............. ok
 04-test_bio_core.t ................. ok
@@ -89,6 +91,7 @@ Result: NOTESTS
 15-test_gendsa.t ................... ok
 15-test_genec.t .................... ok
 15-test_genrsa.t ................... ok
+15-test_gensm2.t ................... ok
 15-test_mp_rsa.t ................... ok
 15-test_out_option.t ............... ok
 15-test_rsa.t ...................... ok
@@ -252,5 +255,5 @@ Result: NOTESTS
 99-test_fuzz_server.t .............. ok
 99-test_fuzz_x509.t ................ ok
 All tests successful.
-Files=250, Tests=3328, 
+Files=253, Tests=3345, 
 Result: PASS


### PR DESCRIPTION
This updates the openssl package in helios following today's release.

This includes security fixes for:

* [CVE-2023-5678 Excessive time spent in DH check / generation with large Q parameter value](https://www.openssl.org/news/secadv/20231106.txt) [LOW severity]
> The OpenSSL SSL/TLS implementation is not affected by this issue.

* [CVE-2023-6129 POLY1305 MAC implementation corrupts vector registers on PowerPC](https://www.openssl.org/news/secadv/20240109.txt) [LOW severity]
> PowerPC CPU based platforms only

* [CVE-2023-6237 Excessive time spent checking invalid RSA public keys](https://www.openssl.org/news/secadv/20240115.txt) [LOW severity]
> The OpenSSL SSL/TLS implementation is not affected by this issue.

* [CVE-2024-0727 PKCS12 Decoding crashes](https://www.openssl.org/news/secadv/20240125.txt) [LOW severity]
> OpenSSL APIs that are vulnerable to this are: PKCS12_parse(), PKCS12_unpack_p7data(), PKCS12_unpack_p7encdata(), PKCS12_unpack_authsafes() and PKCS12_newpass().

None of these affect the product.