### PR TITLE
chrony - update from 4.3 to 4.5

### DIFF
--- a/build/chrony/build.sh
+++ b/build/chrony/build.sh
@@ -17,8 +17,7 @@
 . ../../lib/build.sh
 
 PROG=chrony
-VER=4.3
-DASHREV=1
+VER=4.5
 PKG=service/network/chrony
 SUMMARY="Network time services"
 DESC="A versatile implementation of the Network Time Protocol (NTP)"

--- a/build/chrony/files/chrony.xml
+++ b/build/chrony/files/chrony.xml
@@ -76,7 +76,7 @@
         <exec_method type="method"
                      name="start"
                      exec="/usr/sbin/chronyd"
-                     timeout_seconds="600">
+                     timeout_seconds="60">
             <method_context security_flags="aslr">
                 <method_credential user="root"
                                    group="root"

--- a/build/chrony/patches/illumos.patch
+++ b/build/chrony/patches/illumos.patch
@@ -1,7 +1,7 @@
-diff -wpruN '--exclude=*.orig' a~/configure a/configure
+diff -wpruN --no-dereference '--exclude=*.orig' a~/configure a/configure
 --- a~/configure	1970-01-01 00:00:00
 +++ a/configure	1970-01-01 00:00:00
-@@ -207,6 +207,11 @@ get_features () {
+@@ -208,6 +208,11 @@ get_features () {
  
  
  OPERATINGSYSTEM=`uname -s`
@@ -13,7 +13,7 @@ diff -wpruN '--exclude=*.orig' a~/configure a/configure
  VERSION=`uname -r`
  MACHINE=`uname -m`
  
-@@ -467,7 +472,7 @@ case $OPERATINGSYSTEM in
+@@ -472,7 +477,7 @@ case $OPERATINGSYSTEM in
          fi
          echo "Configuring for macOS (" $SYSTEM "macOS version" $VERSION ")"
      ;;
@@ -22,7 +22,7 @@ diff -wpruN '--exclude=*.orig' a~/configure a/configure
          EXTRA_OBJECTS="sys_generic.o sys_solaris.o sys_timex.o sys_posix.o"
          LIBS="$LIBS -lsocket -lnsl -lkvm -lelf -lresolv"
          try_setsched=1
-@@ -483,6 +488,21 @@ case $OPERATINGSYSTEM in
+@@ -488,6 +493,21 @@ case $OPERATINGSYSTEM in
          fi
          echo "Configuring for illumos (" $SYSTEM "SunOS version" $VERSION ")"
      ;;                                                                        
@@ -44,7 +44,7 @@ diff -wpruN '--exclude=*.orig' a~/configure a/configure
      * )
          echo "error: $SYSTEM is not supported (yet?)"
          exit 1
-diff -wpruN '--exclude=*.orig' a~/privops.c a/privops.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/privops.c a/privops.c
 --- a~/privops.c	1970-01-01 00:00:00
 +++ a/privops.c	1970-01-01 00:00:00
 @@ -34,6 +34,7 @@
@@ -64,7 +64,7 @@ diff -wpruN '--exclude=*.orig' a~/privops.c a/privops.c
      helper_main(sock_fd2);
  
    } else {
-diff -wpruN '--exclude=*.orig' a~/sys.h a/sys.h
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sys.h a/sys.h
 --- a~/sys.h	1970-01-01 00:00:00
 +++ a/sys.h	1970-01-01 00:00:00
 @@ -38,6 +38,7 @@ extern void SYS_Finalise(void);
@@ -75,7 +75,7 @@ diff -wpruN '--exclude=*.orig' a~/sys.h a/sys.h
  } SYS_ProcessContext;
  
  /* Switch to the specified user and group in given context */
-diff -wpruN '--exclude=*.orig' a~/sys_solaris.c a/sys_solaris.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sys_solaris.c a/sys_solaris.c
 --- a~/sys_solaris.c	1970-01-01 00:00:00
 +++ a/sys_solaris.c	1970-01-01 00:00:00
 @@ -34,41 +34,13 @@

--- a/build/chrony/testsuite.log
+++ b/build/chrony/testsuite.log
@@ -1,4 +1,5 @@
 Testing addrfilt                       PASS
+Testing array                          PASS
 Testing clientlog                      PASS
 Testing cmac                           PASS
 Testing hash                           PASS
@@ -8,16 +9,17 @@ Testing ntp_auth                       PASS
 Testing ntp_core                       PASS
 Testing ntp_ext                        PASS
 Testing ntp_sources                    PASS
-Testing nts_ke_client                  SKIP (on line 142)
-Testing nts_ke_server                  SKIP (on line 228)
+Testing nts_ke_client                  SKIP (on line 145)
+Testing nts_ke_server                  SKIP (on line 233)
 Testing nts_ke_session                 SKIP (on line 222)
-Testing nts_ntp_auth                   SKIP (on line 110)
-Testing nts_ntp_client                 SKIP (on line 282)
-Testing nts_ntp_server                 SKIP (on line 174)
+Testing nts_ntp_auth                   SKIP (on line 133)
+Testing nts_ntp_client                 SKIP (on line 300)
+Testing nts_ntp_server                 SKIP (on line 178)
 Testing quantiles                      PASS
 Testing regress                        PASS
 Testing samplefilt                     PASS
-Testing siv                            SKIP (on line 319)
+Testing siv                            SKIP (on line 421)
 Testing smooth                         PASS
+Testing socket                         PASS
 Testing sources                        PASS
 Testing util                           PASS


### PR DESCRIPTION
Catching up with the latest chrony release.  This still doesn't supersede the `local.patch` that adds the new activation thresholds to the local reference.

The two releases consist mostly of bugfixes and features we don't use, but the new `Refresh address of NTP sources periodically` is something that will help in the case that a boundary NTP zone comes up but does not have external connectivity for a prolonged time.
 
https://chrony-project.org/news.html

I've tested this on a bench gimlet with the control plane and it operates as expected.

```
root@oxz_ntp_2bebb7a4:~# chronyc
chrony version 4.5
Copyright (C) 1997-2003, 2007, 2009-2023 Richard P. Curnow and others
chrony comes with ABSOLUTELY NO WARRANTY.  This is free software, and
you are welcome to redistribute it under certain conditions.  See the
GNU General Public License version 2 for details.

chronyc> tracking
Reference ID    : C689CA20 (kjsl-fmt2-net.fmt2.kjsl.com)
Stratum         : 3
Ref time (UTC)  : Fri Apr 19 18:35:36 2024
System time     : 0.000071684 seconds slow of NTP time
Last offset     : -0.000079414 seconds
RMS offset      : 0.017413830 seconds
Frequency       : 81.346 ppm slow
Residual freq   : -0.062 ppm
Skew            : 0.205 ppm
Root delay      : 0.003551559 seconds
Root dispersion : 0.000510156 seconds
Update interval : 1044.0 seconds
Leap status     : Normal
```