### PR TITLE
ncurses - update to 6.4.20240309

### DIFF
--- a/build/ncurses/build.sh
+++ b/build/ncurses/build.sh
@@ -13,15 +13,18 @@
 # }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/build.sh
 
 PROG=ncurses
 VER=6.4
+PATCHLEVEL=20240309
 PKG=library/ncurses
 SUMMARY="A CRT screen handling package"
 DESC="Utilities and shared libraries for terminal handling"
+
+VER+=-$PATCHLEVEL
 
 LD=/usr/ccs/bin/ld
 export LD
@@ -91,7 +94,7 @@ prep_build
 build_abi5
 build_abi6
 make_isa_stub
-make_package
+VER=${VER//-/.} make_package
 clean_up
 
 # Vim hints

--- a/build/ncurses/patches/drop-rin-from-screen-256color.diff
+++ b/build/ncurses/patches/drop-rin-from-screen-256color.diff
@@ -10,7 +10,7 @@ Last-Update: 2019-08-07
 diff -wpruN '--exclude=*.orig' a~/misc/terminfo.src a/misc/terminfo.src
 --- a~/misc/terminfo.src	1970-01-01 00:00:00
 +++ a/misc/terminfo.src	1970-01-01 00:00:00
-@@ -8245,6 +8245,7 @@ screen-16color-bce-s|GNU Screen with 16
+@@ -8308,6 +8308,7 @@ screen-16color-bce-s|GNU Screen with 16
  
  screen-256color|GNU Screen with 256 colors,
  	use=xterm+256setaf, use=screen,

--- a/build/ncurses/patches/sun-color.patch
+++ b/build/ncurses/patches/sun-color.patch
@@ -8,24 +8,24 @@ See: https://www.illumos.org/issues/10359
 diff -wpruN '--exclude=*.orig' a~/misc/terminfo.src a/misc/terminfo.src
 --- a~/misc/terminfo.src	1970-01-01 00:00:00
 +++ a/misc/terminfo.src	1970-01-01 00:00:00
-@@ -8848,9 +8848,9 @@ sun-type4|Sun Workstation console with t
- #	cbt=\E[Z
+@@ -8915,14 +8915,19 @@ sun-type4|Sun Workstation console with t
  #	dim=\E[2m
  #	blink=\E[5m
--# It supports bold, but not underline -TD (2009-09-19)
-+# It supports bold, -TD (2009-09-19)
+ # It supports bold, but not underline -TD (2009-09-19)
++# Replaced klone+color with the first two lines, now that illumos has 256
++# colour support. Added additional capabilities.
  sun-color|Sun Microsystems Workstation console with color support (IA systems),
--	colors#8, ncv#3, pairs#64,
 +	colors#256, ncv#3, pairs#32767,
- 	bold=\E[1m, cub=\E[%p1%dD, cud=\E[%p1%dB, cuf=\E[%p1%dC,
- 	cuu=\E[%p1%dA, home=\E[H, op=\E[0m, rs2=\E[s,
- 	setab=\E[4%p1%dm, setaf=\E[3%p1%dm,
-@@ -8859,7 +8859,7 @@ sun-color|Sun Microsystems Workstation c
++	op=\E[37;40m, setab=\E[4%p1%dm, setaf=\E[3%p1%dm,
+ 	bold=\E[1m, cub1=^H, cud1=\n, home=\E[H, op=\E[0m,
+ 	setb=\E[4%?%p1%{1}%=%t4%e%p1%{3}%=%t6%e%p1%{4}%=%t1%e%p1%{6}
+ 	     %=%t3%e%p1%d%;m,
  	setf=\E[3%?%p1%{1}%=%t4%e%p1%{3}%=%t6%e%p1%{4}%=%t1%e%p1%{6}
  	     %=%t3%e%p1%d%;m,
- 	sgr=\E[0%?%p6%t;1%;%?%p1%p3%|%t;7%;m, sgr0=\E[m,
--	smso=\E[7m, use=sun,
-+	smso=\E[7m, smul=\E[4m, rmul=\E[24m, use=sun,
+ 	sgr=\E[0%?%p6%t;1%;%?%p1%p3%|%t;7%;m, use=ansi+local,
+-	use=sun, use=klone+color,
++	smso=\E[7m, smul=\E[4m, rmul=\E[24m,
++	use=sun,
  
  #### Iris consoles
  #

--- a/build/ncurses/patches/xterm-no-rep.patch
+++ b/build/ncurses/patches/xterm-no-rep.patch
@@ -10,20 +10,21 @@ See also http://invisible-island.net/ncurses/ncurses.faq.html#xterm_generic
 diff -wpruN '--exclude=*.orig' a~/misc/terminfo.src a/misc/terminfo.src
 --- a~/misc/terminfo.src	1970-01-01 00:00:00
 +++ a/misc/terminfo.src	1970-01-01 00:00:00
-@@ -4985,14 +4985,14 @@ xterm-xfree86|xterm terminal emulator (X
+@@ -4946,7 +4946,7 @@ xterm-xfree86|xterm terminal emulator (X
+ 
  xterm+nofkeys|building block for xterm fkey-variants,
  	npc,
- 	kcbt=\E[Z, kent=\EOM, nel=\EE, use=ecma+index,
--	use=ansi+rep, use=ecma+strikeout, use=vt420+lrmm,
-+	use=ecma+strikeout, use=vt420+lrmm,
+-	kcbt=\E[Z, nel=\EE, use=ecma+index, use=ansi+rep,
++	kcbt=\E[Z, nel=\EE, use=ecma+index,
+ 	use=ecma+strikeout, use=vt420+lrmm, use=xterm+focus,
  	use=xterm+sm+1006, use=xterm+tmux, use=ecma+italics,
  	use=xterm+keypad, use=xterm-basic,
- 
+@@ -4954,7 +4954,7 @@ xterm+nofkeys|building block for xterm f
  xterm-p370|xterm patch #370,
- 	npc,
- 	kcbt=\E[Z, kent=\EOM, nel=\EE, use=ecma+index,
--	use=ansi+rep, use=ecma+strikeout, use=xterm+pcfkeys,
-+	use=ecma+strikeout, use=xterm+pcfkeys,
- 	use=xterm+nofkeys, use=bracketed+paste,
- 
- xterm-p371|xterm patch #371,
+ 	rv=\E\\[41;[1-6][0-9][0-9];0c,
+ 	xr=\EP>\\|XTerm\\([1-9][0-9]+\\)\E\\\\,
+-	use=ecma+index, use=ansi+rep, use=ecma+strikeout,
++	use=ecma+index, use=ecma+strikeout,
+ 	use=xterm+pcfkeys, use=xterm+nofkeys,
+ 	use=bracketed+paste, use=report+version,
+ 	use=xterm+focus,


### PR DESCRIPTION
Pulling from the upstream update in OmniOS.

Includes fixes for:
- [CVE-2023-45918](https://www.cve.org/CVERecord?id=CVE-2023-45918)
- [CVE-2023-50495](https://www.cve.org/CVERecord?id=CVE-2023-50495)
