### PR TITLE
rsync: enable IPv6 support

### DIFF
--- a/build/rsync/build.sh
+++ b/build/rsync/build.sh
@@ -19,6 +19,7 @@
 
 PROG=rsync
 VER=3.2.7
+DASHREV=1
 PKG=network/rsync
 SUMMARY="rsync - faster, flexible replacement for rcp"
 DESC="An open source utility that provides fast incremental file transfer"
@@ -54,6 +55,7 @@ CPPFLAGS[aarch64]+=" -I$DEPROOT.aarch64/usr/include"
 
 CONFIGURE_OPTS="
     --with-included-popt
+    --enable-ipv6
 "
 # Needed so that man pages are correctly installed every time
 REMOVE_PREVIOUS=1


### PR DESCRIPTION
IPv6 has never been enabled for rsync in Helios, and it really should be!