### PR TITLE
curl - update from 8.7.1 to 8.9.1

### DIFF
--- a/build/curl/build.sh
+++ b/build/curl/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/build.sh
 
 PROG=curl
-VER=8.7.1
+VER=8.9.1
 PKG=web/curl
 SUMMARY="Command line tool for transferring data with URL syntax"
 DESC="Curl is a command line tool for transferring data with URL syntax, "

--- a/build/curl/testsuite.log
+++ b/build/curl/testsuite.log
@@ -1,3 +1,3 @@
-TESTDONE: 1686 tests were considered during 496 seconds.
-TESTDONE: 1355 tests out of 1356 reported OK: 99%
-TESTFAIL: These test cases failed: 1004 
+TESTDONE: 1713 tests were considered during 499 seconds.
+TESTDONE: 1374 tests out of 1375 reported OK: 99%
+TESTFAIL: These test cases failed: 1004


### PR DESCRIPTION
This includes fixes for two CVEs. For both of these, the affected code is not reachable on Helios due to the use of the OpenSSL backend.

- [CVE-2024-6197: freeing stack buffer in utf8asn1str](https://curl.se/docs/CVE-2024-6197.html) (MEDIUM)
- [CVE-2024-7264: ASN.1 date parser overread](https://curl.se/docs/CVE-2024-7264.html) (LOW)