### PR TITLE
Add system/test/epolltest package

### DIFF
--- a/build/epoll-tests/build.sh
+++ b/build/epoll-tests/build.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+#
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
+#
+. ../../lib/build.sh
+
+PROG=epoll-test-suite
+VER=20240808
+PKG=system/test/epolltest
+SUMMARY="epoll Test Suite"
+DESC="Various functional and stress tests designed to verify the operation of "
+DESC+="an epoll implementation."
+
+# Respect environmental overrides for these to ease development.
+: ${SOURCE_REPO:=$OOCEGITHUB/$PROG}
+: ${SOURCE_BRANCH:=$VER}
+
+SUBDIRS="functional stress"
+PREFIX=/opt
+INSTDIR=$PREFIX/epoll-tests
+
+RUN_DEPENDS_IPS+=" system/test/testrunner"
+SKIP_SSP_CHECK=1
+
+XFORM_ARGS+="
+    -DPREFIX=${PREFIX#/}
+    -DINSTDIR=${INSTDIR#/}
+"
+
+clone_source() {
+    clone_github_source $PROG "$SOURCE_REPO" "$SOURCE_BRANCH"
+    append_builddir $PROG
+    ((EXTRACT_MODE)) && exit
+}
+
+pre_configure() { false; }
+
+make_clean() {
+    for dir in $SUBDIRS; do
+        logmsg "-- cleaning $dir"
+        logcmd $MAKE -C $dir clean
+    done
+}
+
+save_function make_arch _make_arch
+make_arch() {
+    typeset arch=$1
+
+    for dir in $SUBDIRS; do
+        logmsg "-- building $dir tests"
+        MAKE_ARGS+=" -C $dir" _make_arch $arch
+    done
+}
+
+make_install() {
+    logcmd $MKDIR -p $DESTDIR/$INSTDIR || logerr "Failed to create $INSTDIR"
+    for dir in $SUBDIRS; do
+        tgt=$DESTDIR/$INSTDIR/tests/$dir
+        logcmd $MKDIR -p $tgt || logerr "Failed to create $tgt"
+        for xf in $dir/*; do
+            [ -x "$xf" ] || continue
+            logcmd $CP $xf $tgt/ || logerr "Failed to copy $xf"
+        done
+    done
+}
+
+init
+clone_source
+patch_source
+prep_build
+build -noctf
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/epoll-tests/files/functional
+++ b/build/epoll-tests/files/functional
@@ -1,0 +1,27 @@
+#!/usr/bin/ksh
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Oxide Computer Company
+#
+
+export LC_ALL=C.UTF-8
+unalias -a
+
+arg0=$(basename $0)
+rundir="$(dirname $0)/../runfiles"
+file="functional.run"
+runfile="$rundir/$file"
+runner="/opt/test-runner/bin/run"
+
+$runner -c "$runfile"

--- a/build/epoll-tests/files/functional.run
+++ b/build/epoll-tests/files/functional.run
@@ -1,0 +1,44 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Oxide Computer Company
+#
+
+[DEFAULT]
+pre =
+verbose = False
+quiet = False
+timeout = 30
+post =
+outputdir = /var/tmp/test_results
+
+[/opt/epoll-tests/tests/functional]
+tests = [
+	'test_create',
+	'test_depth1',
+	'test_depth2',
+	'test_dir',
+	'test_errevent',
+	'test_et',
+	'test_eventfd_et',
+	'test_exclusive',
+	'test_file',
+	'test_hupevent',
+	'test_illumos',
+	'test_loop',
+	'test_nested',
+	'test_nested_et',
+	'test_oneshot',
+	'test_pipe_et',
+	'test_replace',
+	'test_timeout'
+	]

--- a/build/epoll-tests/local.mog
+++ b/build/epoll-tests/local.mog
@@ -1,0 +1,25 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
+#
+
+license LICENSE license=MPLv2
+
+<transform file path=$(INSTDIR)/tests/ -> set mode 555>
+
+dir  path=$(INSTDIR)/bin
+file files/functional path=$(INSTDIR)/bin/functional \
+    owner=root group=bin mode=555
+
+dir  path=$(INSTDIR)/runfiles
+file files/functional.run path=$(INSTDIR)/runfiles/functional.run \
+    owner=root group=bin mode=444
+


### PR DESCRIPTION
These don't all pass on illumos currently, but it'll be good to have them to allow for easy pre-release testing and checking for regressions.

```
bloody% /opt/epoll-tests/bin/functional
Test: /opt/epoll-tests/tests/functional/test_create (run as af) [00:00] [PASS]
Test: /opt/epoll-tests/tests/functional/test_depth1 (run as af) [00:00] [PASS]
Test: /opt/epoll-tests/tests/functional/test_depth2 (run as af) [00:00] [FAIL]
Test: /opt/epoll-tests/tests/functional/test_dir (run as af)    [00:00] [PASS]
Test: /opt/epoll-tests/tests/functional/test_errevent (run as af) [00:00] [PASS]
Test: /opt/epoll-tests/tests/functional/test_et (run as af)     [00:00] [PASS]
Test: /opt/epoll-tests/tests/functional/test_eventfd_et (run as af) [00:00] [FAIL]   https://www.illumos.org/issues/16700
Test: /opt/epoll-tests/tests/functional/test_exclusive (run as af) [00:00] [PASS]
Test: /opt/epoll-tests/tests/functional/test_file (run as af)   [00:00] [PASS]
Test: /opt/epoll-tests/tests/functional/test_hupevent (run as af) [00:00] [PASS]
Test: /opt/epoll-tests/tests/functional/test_illumos (run as af) [00:00] [PASS]
Test: /opt/epoll-tests/tests/functional/test_loop (run as af)   [00:00] [FAIL]
Test: /opt/epoll-tests/tests/functional/test_nested (run as af) [00:00] [PASS]
Test: /opt/epoll-tests/tests/functional/test_nested_et (run as af) [00:00] [PASS]
Test: /opt/epoll-tests/tests/functional/test_oneshot (run as af) [00:00] [PASS]
Test: /opt/epoll-tests/tests/functional/test_pipe_et (run as af) [00:00] [FAIL]   https://www.illumos.org/issues/13436
Test: /opt/epoll-tests/tests/functional/test_replace (run as af) [00:00] [PASS]
Test: /opt/epoll-tests/tests/functional/test_timeout (run as af) [00:01] [PASS]

Results Summary
PASS      14
FAIL       4

Running Time:   00:00:02
Percent passed: 77.8%
Log directory:  /var/tmp/test_results/20240809T132911
```