### PR TITLE
Update pkg to OmniOS r151050 branch

### DIFF
--- a/build/pkg/build.sh
+++ b/build/pkg/build.sh
@@ -57,12 +57,15 @@ BUILD_DEPENDS_IPS="
 
 # Respect environmental overrides for these to ease development.
 : ${PKG_SOURCE_REPO:=https://github.com/oxidecomputer/pkg5}
-: ${PKG_SOURCE_BRANCH:=helios2}
+: ${PKG_SOURCE_BRANCH:=helios2.1}
 VER+="-$PKG_SOURCE_BRANCH"
+
+# Some python modules require rust for building
+PATH+=:$OOCEBIN
 
 clone_source() {
     clone_github_source pkg \
-        "$PKG_SOURCE_REPO" "$PKG_SOURCE_BRANCH" "$PKG5_CLONE"
+        "$PKG_SOURCE_REPO" "$PKG_SOURCE_BRANCH" "$PKG5_CLONE" 0
     ((EXTRACT_MODE)) && exit
 }
 
@@ -78,9 +81,11 @@ build() {
 
 package() {
     pushd $TMPDIR/$BUILDDIR/pkg/src/pkg > /dev/null
+    COMMITCOUNT=`$GIT rev-list --count HEAD`
     logmsg "--- packaging"
     logcmd make check publish-pkgs \
         BUILDNUM=$BUILDNUM \
+        PKGVERS_BRANCH=$BUILDNUM.1.$COMMITCOUNT \
         PKGSEND_OPTS="" \
         PKGPUBLISHER=$PKGPUBLISHER \
         PKGREPOTGT="" \

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1487,8 +1487,9 @@ clone_github_source() {
         logcmd $GIT -C $prog clean -fdx
         fresh=1
     elif [ ! -d $prog ]; then
-        logcmd $GIT clone --no-single-branch --depth $depth $src $prog \
-            || logerr "clone failed"
+        typeset args="--no-single-branch"
+        ((depth > 0)) && args+=" --depth $depth"
+        logcmd $GIT clone $args $src $prog || logerr "clone failed"
         fresh=1
     else
         logmsg "Using existing checkout"


### PR DESCRIPTION
This updates `pkg` to the helios 2.1 branch which is based on the OmniOS r151050 stable branch.
Since r50 ships python 3.12, I have reverted this back to python 3.11 for helios and since helios does not have a qemu package, I've also removed the emu brand.

You can view the few helios changes after that on the branch at https://github.com/oxidecomputer/pkg5/commits/helios2.1/

I've built updated packages on a helios VM running `helios-2.0.22241` - the same version that the existing published pkg package has - which should ease updates. That is, `pkg update pkg` should be uneventful when it is recommended by the tool.

On atrium, a dry run update looks good:

```
atrium% pfexec pkg update -nv -g pkg.p5p pkg
            Packages to update:         1
     Estimated space available: 692.67 GB
Estimated space to be consumed: 218.99 MB
       Create boot environment:        No
Create backup boot environment:       Yes
          Rebuild boot archive:        No

Changed packages:
helios-dev
  package/pkg
    0.5.11-2.0 -> 0.5.11-2.1

Editable files to change:
  Update:
    usr/share/lib/pkg/web/config.shtml
```

The full IPS test suite on this branch was also successful on atrium.