### PR TITLE
openssl - update from 3.0.14 to 3.0.15

### DIFF
--- a/build/openssl/build-3.sh
+++ b/build/openssl/build-3.sh
@@ -19,7 +19,7 @@
 . common.sh
 
 PROG=openssl
-VER=3.0.14
+VER=3.0.15
 PKG=library/security/openssl-3
 SUMMARY="Cryptography and SSL/TLS Toolkit"
 DESC="A toolkit for Secure Sockets Layer and Transport Layer protocols "

--- a/build/openssl/testsuite-3.log
+++ b/build/openssl/testsuite-3.log
@@ -128,6 +128,7 @@ Result: NOTESTS
 30-test_defltfips.t ................ ok
 30-test_engine.t ................... ok
 30-test_evp.t ...................... ok
+30-test_evp_byname.t ............... ok
 30-test_evp_extra.t ................ ok
 30-test_evp_fetch_prov.t ........... ok
 30-test_evp_kdf.t .................. ok
@@ -161,6 +162,7 @@ Result: NOTESTS
 70-test_clienthello.t .............. ok
 70-test_comp.t ..................... ok
 70-test_key_share.t ................ ok
+70-test_npn.t ...................... ok
 70-test_packet.t ................... ok
 70-test_recordlen.t ................ ok
 70-test_renegotiation.t ............ ok
@@ -255,5 +257,5 @@ Result: NOTESTS
 99-test_fuzz_server.t .............. ok
 99-test_fuzz_x509.t ................ ok
 All tests successful.
-Files=253, Tests=3350, 
+Files=255, Tests=3358, 
 Result: PASS


### PR DESCRIPTION
Includes a fix for [CVE-2024-6119](https://openssl-library.org/news/secadv/20240903.txt)

This relates to applications performing certificate name checks involving an `otherName` subject alternative name.
The vulnerability mostly affects clients performing these checks and involves reading an invalid memory address.
From the advisory:
> TLS servers rarely solicit client certificates, and even when they do, they
generally don't perform a name check against a "reference identifier" (expected
identity), but rather extract the presented identity after checking the
certificate chain.  So TLS servers are generally not affected and the severity
of the issue is Moderate.