### PR TITLE
git - update from 2.40.1 to 2.40.3

### DIFF
--- a/build/git/build.sh
+++ b/build/git/build.sh
@@ -14,12 +14,12 @@
 #
 # Copyright (c) 2014 by Delphix. All rights reserved.
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/build.sh
 
 PROG=git
-VER=2.40.1
+VER=2.40.3
 PKG=developer/versioning/git
 SUMMARY="$PROG - distributed version control system"
 DESC="Git is a free and open source distributed version control system "

--- a/build/git/testsuite.log
+++ b/build/git/testsuite.log
@@ -1,7 +1,7 @@
     * new script parameters
     * new perl-specific parameters
 *** t0000-basic.sh ***
-# passed all 91 test(s)
+# passed all 92 test(s)
 *** t0001-init.sh ***
 # passed all 61 test(s)
 *** t0002-gitfile.sh ***
@@ -64,7 +64,7 @@
 *** t0032-reftable-unittest.sh ***
 # passed all 1 test(s)
 *** t0033-safe-directory.sh ***
-# passed all 12 test(s)
+# passed all 14 test(s)
 *** t0034-root-safe-directory.sh ***
 *** t0035-safe-bare-repository.sh ***
 # passed all 7 test(s)


### PR DESCRIPTION
> This release merges up the fix that appears in v2.39.4 to address
the security issues CVE-2024-32002, CVE-2024-32004, CVE-2024-32020,
CVE-2024-32021 and CVE-2024-32465...

```
 * CVE-2024-32002:

   Recursive clones on case-insensitive filesystems that support symbolic
   links are susceptible to case confusion that can be exploited to
   execute just-cloned code during the clone operation.

 * CVE-2024-32004:

   Repositories can be configured to execute arbitrary code during local
   clones. To address this, the ownership checks introduced in v2.30.3
   are now extended to cover cloning local repositories.

 * CVE-2024-32020:

   Local clones may end up hardlinking files into the target repository's
   object database when source and target repository reside on the same
   disk. If the source repository is owned by a different user, then
   those hardlinked files may be rewritten at any point in time by the
   untrusted user.

 * CVE-2024-32021:

   When cloning a local source repository that contains symlinks via the
   filesystem, Git may create hardlinks to arbitrary user-readable files
   on the same filesystem as the target repository in the objects/
   directory.

 * CVE-2024-32465:

   It is supposed to be safe to clone untrusted repositories, even those
   unpacked from zip archives or tarballs originating from untrusted
   sources, but Git can be tricked to run arbitrary code as part of the
   clone.
```