### PR TITLE
python311 - update from 3.11.9 to 3.11.10

### DIFF
--- a/build/python311/build.sh
+++ b/build/python311/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=Python
-VER=3.11.9
+VER=3.11.10
 PKG=runtime/python-311
 MVER=${VER%.*}
 SUMMARY="$PROG $MVER"

--- a/build/python311/patches/mod-posix-sched_priority.patch
+++ b/build/python311/patches/mod-posix-sched_priority.patch
@@ -7,7 +7,7 @@ However, -1 alongside EINVAL represents an error.
 diff -wpruN --no-dereference '--exclude=*.orig' a~/Modules/posixmodule.c a/Modules/posixmodule.c
 --- a~/Modules/posixmodule.c	1970-01-01 00:00:00
 +++ a/Modules/posixmodule.c	1970-01-01 00:00:00
-@@ -6901,7 +6901,11 @@ os_sched_get_priority_max_impl(PyObject
+@@ -6939,7 +6939,11 @@ os_sched_get_priority_max_impl(PyObject
      int max;
  
      max = sched_get_priority_max(policy);
@@ -19,7 +19,7 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/Modules/posixmodule.c a/Modul
          return posix_error();
      return PyLong_FromLong(max);
  }
-@@ -6920,7 +6924,11 @@ os_sched_get_priority_min_impl(PyObject
+@@ -6958,7 +6962,11 @@ os_sched_get_priority_min_impl(PyObject
  /*[clinic end generated code: output=7595c1138cc47a6d input=21bc8fa0d70983bf]*/
  {
      int min = sched_get_priority_min(policy);

--- a/build/python311/patches/test-tarfile.patch
+++ b/build/python311/patches/test-tarfile.patch
@@ -9,7 +9,7 @@ Convert both timestamps to integer before comparing.
 diff -wpruN --no-dereference '--exclude=*.orig' a~/Lib/test/test_tarfile.py a/Lib/test/test_tarfile.py
 --- a~/Lib/test/test_tarfile.py	1970-01-01 00:00:00
 +++ a/Lib/test/test_tarfile.py	1970-01-01 00:00:00
-@@ -3091,7 +3091,7 @@ class NoneInfoExtractTests(ReadTest):
+@@ -3133,7 +3133,7 @@ class NoneInfoExtractTests(ReadTest):
                          if not path.is_symlink():
                              raise
                      else:


### PR DESCRIPTION
This update includes a number of security related fixes, particular around the libraries for parsing zip and tar files. I'm cherry picking this from an upcoming OmniOS release.