### PR TITLE
expat need not link with libm

### DIFF
--- a/build/expat/build.sh
+++ b/build/expat/build.sh
@@ -25,7 +25,10 @@ DESC="Fast streaming XML parser written in C"
 
 forgo_isaexec
 
-CONFIGURE_OPTS="--disable-static"
+CONFIGURE_OPTS="
+    --disable-static
+    ac_cv_lib_m_cos=no
+"
 
 TESTSUITE_SED="
     /^[^#]/d


### PR DESCRIPTION
libexpat unnecessarily links libm, which then falls foul of the
illumos ELF runtime checks:

```
==== Check ELF runtime attributes ====

usr/lib/hal/hald: unreferenced
object=/oxide/stlouis/projects/illumos/proto/root_i386/lib/libm.so.2; unused
dependency of /usr/lib/libexpat.so.1              <remove lib or -zignore?>
```

This patch from OmniOS stops that from happening (and has been in OmniOS
since February).

