### PR TITLE
git - update from 2.40.3 to 2.40.4

### DIFF
--- a/build/git/build.sh
+++ b/build/git/build.sh
@@ -14,12 +14,12 @@
 #
 # Copyright (c) 2014 by Delphix. All rights reserved.
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/build.sh
 
 PROG=git
-VER=2.40.3
+VER=2.40.4
 PKG=developer/versioning/git
 SUMMARY="$PROG - distributed version control system"
 DESC="Git is a free and open source distributed version control system "


### PR DESCRIPTION
The addressed issues are:

    - CVE-2024-50349:

      Printing unsanitized URLs when asking for credentials makes the user
      susceptible to crafted URLs (e.g. in recursive clones). These URLs
      can mislead the user into typing in passwords for trusted sites that
      would then be sent to untrusted sites instead.

      A potential scenario of how this can be exploited is a recursive
      clone where one of the submodules prompts for a password, pretending
      to ask for a different host than the password will be sent to.

    - CVE-2024-52006:

      Git may pass on Carriage Returns via the credential protocol to
      credential helpers which use line-reading functions that interpret
      Carriage Returns as line endings, even though this is not what was
      intended (but Git’s documentation did not clarify that "newline"
      meant "Line Feed character").

      This affected the popular .NET-based Git Credential Manager, which
      has been updated accordingly in coordination with the Git project.