### PR TITLE
rsync - update from 3.2.7 to 3.4.0

### DIFF
--- a/build/rsync/build.sh
+++ b/build/rsync/build.sh
@@ -13,13 +13,12 @@
 # }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2022 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/build.sh
 
 PROG=rsync
-VER=3.2.7
-DASHREV=1
+VER=3.4.0
 PKG=network/rsync
 SUMMARY="rsync - faster, flexible replacement for rcp"
 DESC="An open source utility that provides fast incremental file transfer"

--- a/build/rsync/testsuite.log
+++ b/build/rsync/testsuite.log
@@ -35,6 +35,7 @@ PASS    missing
 PASS    mkpath
 SKIP    protected-regular (Can't find protected_regular setting (only available on Linux))
 PASS    relative
+PASS    safe-links
 PASS    ssh-basic
 PASS    symlink-ignore
 PASS    trimslash
@@ -45,6 +46,6 @@ PASS    xattrs-hlink
 PASS    xattrs
 ------------------------------------------------------------
 ----- overall results:
-      39 passed
+      40 passed
       6 skipped
 ------------------------------------------------------------


### PR DESCRIPTION
[1] Heap Buffer Overflow in Rsync due to Improper Checksum Length Handling

CVE ID: CVE-2024-12084

CVSS 3.1: 9.8 - AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

Description: A heap-based buffer overflow flaw was found in the rsync
daemon. This issue is due to improper handling of attacker-controlled
checksum lengths (s2length) in the code. When MAX_DIGEST_LEN exceeds the
fixed SUM_LENGTH (16 bytes), an attacker can write out of bounds in the
sum2 buffer.

Affected Versions: >= 3.2.7 and < 3.4.0
Reporters: Simon Scannell from Google, Pedro Gallegos from Google, Jasiel
Spelman from Google

Mitigation: Disable SHA* support by compiling with
CFLAGS=-DDISABLE_SHA512_DIGEST and CFLAGS=-DDISABLE_SHA256_DIGEST.

----------

[2] Info Leak via Uninitialized Stack Contents

CVE ID: CVE-2024-12085

CVSS 3.1: 7.5 - AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N

Description: A flaw was found in the rsync daemon which could be triggered
when rsync compares file checksums. This flaw allows an attacker to
manipulate the checksum length (s2length) to cause a comparison between a
checksum and uninitialized memory and leak one byte of uninitialized stack
data at a time.

Affected Versions: < 3.4.0

Reporters: Simon Scannell from Google, Pedro Gallegos from Google, Jasiel
Spelman from Google

Mitigation: Compile with -ftrivial-auto-var-init=zero to zero the stack
contents.

----------

[3] Rsync Server Leaks Arbitrary Client Files

CVE ID: CVE-2024-12086

CVSS 3.1: 6.1 - AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:N/A:N

Description: A flaw was found in rsync. It could allow a server to
enumerate the contents of an arbitrary file from the client's machine. This
issue occurs when files are being copied from a client to a server. During
this process, the rsync server will send checksums of local data to the
client to compare with in order to determine what data needs to be sent to
the server. By sending specially constructed checksum values for arbitrary
files, an attacker may be able to reconstruct the data of those files
byte-by-byte based on the responses from the client.

Affected Versions: < 3.4.0

Reporters: Simon Scannell from Google, Pedro Gallegos from Google, Jasiel
Spelman from Google

----------

[4] Path Traversal Vulnerability in Rsync

CVE ID: CVE-2024-12087

CVSS 3.1: 6.5 - AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N

Description: A path traversal vulnerability exists in rsync. It stems from
behavior enabled by the `--inc-recursive` option, a default-enabled option
for many client options and can be enabled by the server even if not
explicitly enabled by the client. When using the `--inc-recursive` option,
a lack of proper symlink verification coupled with deduplication checks
occurring on a per-file-list basis could allow a server to write files
outside of the client's intended destination directory. A malicious server
could write malicious files to arbitrary locations named after valid
directories/paths on the client.

Affected Versions: < 3.4.0
Reporters: Simon Scannell from Google, Pedro Gallegos from Google, Jasiel
Spelman from Google

----------

[5] --safe-links Option Bypass Leads to Path Traversal

CVE ID: CVE-2024-12088

CVSS 3.1: 6.5 - AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N

Description: A flaw was found in rsync. When using the `--safe-links`
option, rsync fails to properly verify if a symbolic link destination
contains another symbolic link within it. This results in a path traversal
vulnerability, which may lead to arbitrary file write outside the desired
directory.

Affected Versions: < 3.4.0

Reporters: Simon Scannell from Google, Pedro Gallegos from Google, Jasiel
Spelman from Google

----------

[6] Race Condition in Rsync Handling Symbolic Links

CVE ID: CVE-2024-12747

CVSS 3.1: 5.6 - AV:L/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N

Description: A flaw was found in rsync. This vulnerability arises from a
race condition during rsync's handling of symbolic links. Rsync's default
behavior when encountering symbolic links is to skip them. If an attacker
replaced a regular file with a symbolic link at the right time, it was
possible to bypass the default behavior and traverse symbolic links.
Depending on the privileges of the rsync process, an attacker could leak
sensitive information, potentially leading to privilege escalation.

Affected Versions: < 3.4.0