### PR TITLE
rsync - update from 3.4.0 to 3.4.1

### DIFF
--- a/build/rsync/build.sh
+++ b/build/rsync/build.sh
@@ -18,12 +18,12 @@
 . ../../lib/build.sh
 
 PROG=rsync
-VER=3.4.0
+VER=3.4.1
 PKG=network/rsync
 SUMMARY="rsync - faster, flexible replacement for rcp"
 DESC="An open source utility that provides fast incremental file transfer"
 
-XXHASHVER=0.8.1
+XXHASHVER=0.8.3
 XFORM_ARGS+=" -DXXHASH=$XXHASHVER"
 
 set_arch 64


### PR DESCRIPTION
This is a fix for some regressions introduced in 3.4.0