### PR TITLE
openssl - update from 3.0.15 to 3.0.16

### DIFF
--- a/build/openssl/build-3.sh
+++ b/build/openssl/build-3.sh
@@ -13,13 +13,13 @@
 # }}}
 #
 # Copyright 2017 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
 #
 . ../../lib/build.sh
 . common.sh
 
 PROG=openssl
-VER=3.0.15
+VER=3.0.16
 PKG=library/security/openssl-3
 SUMMARY="Cryptography and SSL/TLS Toolkit"
 DESC="A toolkit for Secure Sockets Layer and Transport Layer protocols "

--- a/build/openssl/testsuite-3.log
+++ b/build/openssl/testsuite-3.log
@@ -108,6 +108,7 @@ Result: NOTESTS
 20-test_kdf.t ...................... ok
 20-test_legacy_okay.t .............. ok
 20-test_mac.t ...................... ok
+20-test_nocache.t .................. ok
 20-test_passwd.t ................... ok
 20-test_pkeyutl.t .................. ok
 20-test_rand_config.t .............. ok
@@ -146,6 +147,7 @@ Result: NOTESTS
 60-test_x509_store.t ............... ok
 60-test_x509_time.t ................ ok
 61-test_bio_prefix.t ............... ok
+61-test_bio_pw_callback.t .......... ok
 61-test_bio_readbuffer.t ........... ok
 65-test_cmp_asn.t .................. ok
 65-test_cmp_client.t ............... ok
@@ -257,5 +259,5 @@ Result: NOTESTS
 99-test_fuzz_server.t .............. ok
 99-test_fuzz_x509.t ................ ok
 All tests successful.
-Files=255, Tests=3358, 
+Files=257, Tests=3364, 
 Result: PASS


### PR DESCRIPTION
From upstream https://github.com/omniosorg/omnios-build/pull/3849

This fixes two low severity CVEs:

https://openssl-library.org/news/vulnerabilities/index.html#CVE-2024-13176
https://openssl-library.org/news/vulnerabilities/index.html#CVE-2024-9143

