### PR TITLE
vim - update to 9.0.2136

### DIFF
--- a/build/vim/build.sh
+++ b/build/vim/build.sh
@@ -19,7 +19,7 @@
 
 PROG=vim
 VER=9.0
-PATCHLEVEL=1443
+PATCHLEVEL=2136
 PKG=editor/vim
 SUMMARY="Vi IMproved"
 DESC="Advanced text editor that provides the power of the UNIX vi editor "


### PR DESCRIPTION
I mostly want JSON5 syntax highlighting support which came in with v9.0.2041
.2136 was also the last stopping point in the 9.0 train for upstream OmniOS LTS based on security fixes.