### PR TITLE
expat: update from 2.6.4 to 2.7.1

### DIFF
--- a/build/expat/build.sh
+++ b/build/expat/build.sh
@@ -13,12 +13,12 @@
 # }}}
 #
 # Copyright 2011-2012 OmniTI Computer Consulting, Inc.  All rights reserved.
-# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
 
 . ../../lib/build.sh
 
 PROG=expat
-VER=2.6.4
+VER=2.7.1
 PKG=library/expat
 SUMMARY="XML parser library"
 DESC="Fast streaming XML parser written in C"

--- a/build/expat/patches/no_link_libm.patch
+++ b/build/expat/patches/no_link_libm.patch
@@ -1,7 +1,7 @@
-diff -wpruN --no-dereference '--exclude=*.orig' a~/m4/libtool.m4 a/m4/libtool.m4
+diff -wpruN '--exclude=*.orig' a~/m4/libtool.m4 a/m4/libtool.m4
 --- a~/m4/libtool.m4	1970-01-01 00:00:00
 +++ a/m4/libtool.m4	1970-01-01 00:00:00
-@@ -3882,7 +3882,7 @@ case $host in
+@@ -3998,7 +3998,7 @@ case $host in
    AC_CHECK_LIB(m, cos, LIBM="$LIBM -lm")
    ;;
  *)


### PR DESCRIPTION
This fixes CVE-2024-8176 and a regression that was introduced in the original fix for it.

#### 2.7.0
```
       #893 #973  CVE-2024-8176 -- Fix crash from chaining a large number
                    of entities caused by stack overflow by resolving use of
                    recursion, for all three uses of entities:
                    - general entities in character data ("<e>&g1;</e>")
                    - general entities in attribute values ("<e k1='&g1;'/>")
                    - parameter entities ("%p1;")
                    Known impact is (reliable and easy) denial of service:
                    CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:H/RL:O/RC:C
                    (Base Score: 7.5, Temporal Score: 7.2)
                    Please note that a layer of compression around XML can
                    significantly reduce the minimum attack payload size.
```

#### 2.7.1
```
        Bug fixes:
       #980 #989  Restore event pointer behavior from Expat 2.6.4
                    (that the fix to CVE-2024-8176 changed in 2.7.0);
                    affected API functions are:
                    - XML_GetCurrentByteCount
                    - XML_GetCurrentByteIndex
                    - XML_GetCurrentColumnNumber
                    - XML_GetCurrentLineNumber
                    - XML_GetInputContext
```