### PR TITLE
openssl - update from 3.0.16 to 3.0.17

### DIFF
--- a/build/openssl/build-3.sh
+++ b/build/openssl/build-3.sh
@@ -19,7 +19,7 @@
 . common.sh
 
 PROG=openssl
-VER=3.0.16
+VER=3.0.17
 PKG=library/security/openssl-3
 SUMMARY="Cryptography and SSL/TLS Toolkit"
 DESC="A toolkit for Secure Sockets Layer and Transport Layer protocols "

--- a/build/openssl/testsuite-3.log
+++ b/build/openssl/testsuite-3.log
@@ -259,5 +259,5 @@ Result: NOTESTS
 99-test_fuzz_server.t .............. ok
 99-test_fuzz_x509.t ................ ok
 All tests successful.
-Files=257, Tests=3364, 
+Files=257, Tests=3375, 
 Result: PASS


### PR DESCRIPTION
Fixes https://openssl-library.org/news/vulnerabilities/index.html#CVE-2025-4575
which is a low-severity CVE.