### PR TITLE
illumos-tools: update gcc dependencies

### DIFF
--- a/build/meta/illumos-tools.p5m
+++ b/build/meta/illumos-tools.p5m
@@ -7,8 +7,8 @@ depend fmri=developer/astdev type=require
 depend fmri=developer/build/make type=require
 depend fmri=developer/build/onbld type=require
 depend fmri=developer/debug/ctf type=require
+depend fmri=developer/gcc14 type=require
 depend fmri=developer/gcc10 type=require
-depend fmri=developer/gcc7 type=require
 depend fmri=developer/gnu-binutils type=require
 depend fmri=developer/illumos-closed type=require
 depend fmri=developer/lexer/flex type=require


### PR DESCRIPTION
The gate has long used gcc10 as the primary compiler with gcc14 as a shadow.  Update this so those following the helios build instructions do not stumble over absent required versions.