### PR TITLE
expat - update from 2.7.1 to 2.7.2

### DIFF
--- a/build/expat/build.sh
+++ b/build/expat/build.sh
@@ -18,7 +18,7 @@
 . ../../lib/build.sh
 
 PROG=expat
-VER=2.7.1
+VER=2.7.2
 PKG=library/expat
 SUMMARY="XML parser library"
 DESC="Fast streaming XML parser written in C"


### PR DESCRIPTION
```
Release 2.7.2 Tue September 16 2025
        Security fixes:
     #1018 #1034  CVE-2025-59375 -- Disallow use of disproportional amounts of
                    dynamic memory from within an Expat parser (e.g. previously
                    a ~250 KiB sized document was able to cause allocation of
                    ~800 MiB from the heap, i.e. an "amplification" of factor
                    ~3,300)
```