### PR TITLE
openssl - update from 3.0.17 to 3.0.18

### DIFF
--- a/build/openssl/build-3.sh
+++ b/build/openssl/build-3.sh
@@ -19,7 +19,7 @@
 . common.sh
 
 PROG=openssl
-VER=3.0.17
+VER=3.0.18
 PKG=library/security/openssl-3
 SUMMARY="Cryptography and SSL/TLS Toolkit"
 DESC="A toolkit for Secure Sockets Layer and Transport Layer protocols "

--- a/build/openssl/testsuite-3.log
+++ b/build/openssl/testsuite-3.log
@@ -259,5 +259,5 @@ Result: NOTESTS
 99-test_fuzz_server.t .............. ok
 99-test_fuzz_x509.t ................ ok
 All tests successful.
-Files=257, Tests=3375, 
+Files=257, Tests=3377, 
 Result: PASS


### PR DESCRIPTION
Includes fixes for:

 * CVE-2025-9230 - Fix Out-of-bounds read & write in RFC 3211 KEK Unwrap.
 * CVE-2025-9232 - Fix Out-of-bounds read in HTTP client no_proxy handling.
