### PR TITLE
git - update from 2.40.4 to 2.49.1

### DIFF
--- a/build/git/build.sh
+++ b/build/git/build.sh
@@ -19,7 +19,7 @@
 . ../../lib/build.sh
 
 PROG=git
-VER=2.40.4
+VER=2.49.1
 PKG=developer/versioning/git
 SUMMARY="$PROG - distributed version control system"
 DESC="Git is a free and open source distributed version control system "
@@ -27,6 +27,10 @@ DESC+="designed to handle everything from small to very large projects with "
 DESC+="speed and efficiency."
 
 set_arch 64
+# This is needed to convince git that we have a new enough iconv(3c) to use
+# non-const char * parameters. As of gcc14, the compiler correctly rejects
+# the mismatch that otherwise occurs.
+set_standard XPG6
 
 BUILD_DEPENDS_IPS="
     compatibility/ucb

--- a/build/git/testsuite.log
+++ b/build/git/testsuite.log
@@ -3,41 +3,33 @@
 *** t0000-basic.sh ***
 # passed all 92 test(s)
 *** t0001-init.sh ***
-# passed all 61 test(s)
+# passed all 96 test(s)
 *** t0002-gitfile.sh ***
 # passed all 14 test(s)
 *** t0003-attributes.sh ***
-# passed all 40 test(s)
+# passed all 54 test(s)
 *** t0004-unwritable.sh ***
 # passed all 9 test(s)
 *** t0005-signals.sh ***
 # passed all 5 test(s)
 *** t0006-date.sh ***
-# passed all 94 test(s)
+# passed all 129 test(s)
 *** t0007-git-var.sh ***
-# passed all 18 test(s)
+# passed all 27 test(s)
 *** t0008-ignores.sh ***
-# passed all 396 test(s)
-*** t0009-prio-queue.sh ***
-# passed all 4 test(s)
+# passed all 397 test(s)
 *** t0010-racy-git.sh ***
 # passed all 10 test(s)
-*** t0011-hashmap.sh ***
-# passed all 14 test(s)
 *** t0012-help.sh ***
-# passed all 172 test(s)
+# passed all 175 test(s)
 *** t0013-sha1dc.sh ***
 # passed all 1 test(s)
 *** t0014-alias.sh ***
-# passed all 4 test(s)
-*** t0015-hash.sh ***
-# passed all 2 test(s)
-*** t0016-oidmap.sh ***
-# passed all 6 test(s)
+# passed all 5 test(s)
 *** t0017-env-helper.sh ***
 # passed all 5 test(s)
 *** t0018-advice.sh ***
-# passed all 3 test(s)
+# passed all 6 test(s)
 *** t0019-json-writer.sh ***
 # passed all 16 test(s)
 *** t0020-crlf.sh ***
@@ -55,21 +47,19 @@
 *** t0026-eol-config.sh ***
 # passed all 6 test(s)
 *** t0027-auto-crlf.sh ***
-# passed all 1466 test(s)
+# passed all 2600 test(s)
 *** t0028-working-tree-encoding.sh ***
 # passed all 22 test(s)
 *** t0029-core-unsetenvvars.sh ***
 *** t0030-stripspace.sh ***
-# passed all 27 test(s)
-*** t0032-reftable-unittest.sh ***
-# passed all 1 test(s)
+# passed all 30 test(s)
 *** t0033-safe-directory.sh ***
-# passed all 14 test(s)
+# passed all 22 test(s)
 *** t0034-root-safe-directory.sh ***
 *** t0035-safe-bare-repository.sh ***
-# passed all 7 test(s)
+# passed all 12 test(s)
 *** t0040-parse-options.sh ***
-# passed all 86 test(s)
+# passed all 90 test(s)
 *** t0041-usage.sh ***
 # passed all 16 test(s)
 *** t0050-filesystem.sh ***
@@ -82,43 +72,39 @@
 *** t0056-git-C.sh ***
 # passed all 11 test(s)
 *** t0060-path-utils.sh ***
-# passed all 218 test(s)
+# passed all 219 test(s)
 *** t0061-run-command.sh ***
 # passed all 23 test(s)
 *** t0062-revision-walking.sh ***
 # passed all 2 test(s)
 *** t0063-string-list.sh ***
-# passed all 9 test(s)
-*** t0064-oid-array.sh ***
-# passed all 8 test(s)
-*** t0065-strcmp-offset.sh ***
-# passed all 4 test(s)
+# passed all 14 test(s)
 *** t0066-dir-iterator.sh ***
 # passed all 10 test(s)
 *** t0067-parse_pathspec_file.sh ***
 # passed all 8 test(s)
 *** t0068-for-each-repo.sh ***
-# passed all 2 test(s)
-*** t0069-oidtree.sh ***
-# passed all 2 test(s)
+# passed all 5 test(s)
 *** t0070-fundamental.sh ***
-# passed all 8 test(s)
+# passed all 11 test(s)
 *** t0071-sort.sh ***
 # passed all 1 test(s)
+*** t0080-unit-test-output.sh ***
+# passed all 1 test(s)
+*** t0081-find-pack.sh ***
+# passed all 4 test(s)
 *** t0090-cache-tree.sh ***
 # passed all 22 test(s)
 *** t0091-bugreport.sh ***
-# passed all 10 test(s)
+# passed all 13 test(s)
 *** t0092-diagnose.sh ***
 # passed all 4 test(s)
 *** t0095-bloom.sh ***
-# passed all 10 test(s)
+# passed all 11 test(s)
 *** t0100-previous.sh ***
 # passed all 6 test(s)
 *** t0101-at-syntax.sh ***
 # passed all 8 test(s)
-*** t0110-urlmatch-normalization.sh ***
-# passed all 11 test(s)
 *** t0200-gettext-basic.sh ***
 # lib-gettext: Found 'is_IS.UTF-8' as an is_IS UTF-8 locale
 # lib-gettext: Found 'is_IS.ISO8859-1' as an is_IS ISO-8859-1 locale
@@ -151,6 +137,6 @@ not ok 6 - gettext: Fetching a UTF-8 msgid -> ISO-8859-1
 #	    grep "$(echo tvöfaldar | iconv -f UTF-8 -t ISO8859-1)" actual
 #	
 # failed 2 among 8 test(s)
-make[2]: *** [Makefile:66: t0204-gettext-reencode-sanity.sh] Error 1
-make[1]: *** [Makefile:53: test] Error 2
-make: *** [Makefile:3193: test] Error 2
+make[2]: *** [Makefile:77: t0204-gettext-reencode-sanity.sh] Error 1
+make[1]: *** [Makefile:63: test] Error 2
+make: *** [Makefile:3274: test] Error 2


### PR DESCRIPTION
This updates `git` to the same version that is in Heliosv3 (based on OmniOS
r151054). Recent versions of `jj` require at least git 2.41.0

```
% jj git fetch
Error: Git does not recognize required option: porcelain (note: supported
version is 2.41.0)
```
