### PR TITLE
openssl - update from 3.5.6 to 3.5.7

### DIFF
--- a/build/openssl/build-3.sh
+++ b/build/openssl/build-3.sh
@@ -19,7 +19,7 @@
 . common.sh
 
 PROG=openssl
-VER=3.5.6
+VER=3.5.7
 PKG=library/security/openssl-3
 SUMMARY="Cryptography and SSL/TLS Toolkit"
 DESC="A toolkit for Secure Sockets Layer and Transport Layer protocols "

--- a/build/openssl/testsuite-3.log
+++ b/build/openssl/testsuite-3.log
@@ -118,6 +118,7 @@ Result: NOTESTS
 15-test_sha.t ........................... ok
 20-test_app.t ........................... ok
 20-test_cli_fips.t ...................... skipped: Test only supported in a fips build with security checks
+20-test_cli_list.t ...................... ok
 20-test_dgst.t .......................... ok
 20-test_dhparam.t ....................... ok
 20-test_dhparam_check.t ................. ok
@@ -238,6 +239,7 @@ Result: NOTESTS
 70-test_tls13kexmodes.t ................. ok
 70-test_tls13messages.t ................. ok
 70-test_tls13psk.t ...................... ok
+70-test_tls13ticket.t ................... ok
 70-test_tlsextms.t ...................... ok
 70-test_verify_extra.t .................. ok
 70-test_wpacket.t ....................... ok
@@ -344,5 +346,5 @@ Result: NOTESTS
 99-test_fuzz_v3name.t ................... ok
 99-test_fuzz_x509.t ..................... ok
 All tests successful.
-Files=342, Tests=4456, 
+Files=344, Tests=4487, 
 Result: PASS


### PR DESCRIPTION
```
OpenSSL 3.5.7 is a security patch release.  The most severe CVE fixed
in this release is High.

This release incorporates the following bug fixes and mitigations:

  * Fixed heap use-after-free in `PKCS7_verify()`.
    ([CVE-2026-45447])

  * Fixed CMS `AuthEnvelopedData` processing may accept forged messages.
    ([CVE-2026-34182])

  * Fixed unbounded memory growth in the QUIC `PATH_CHALLENGE` handler.
    ([CVE-2026-34183])

  * Fixed NULL pointer dereference in QUIC server initial packet handling.
    ([CVE-2026-42764])

  * Fixed AES-OCB IV ignored on `EVP_Cipher()` path.
    ([CVE-2026-45445])

  * Fixed possible heap buffer overflow in ASN.1 multibyte string conversion.
    ([CVE-2026-7383])

  * Fixed out-of-bounds read in CMS password-based decryption.
    ([CVE-2026-9076])

  * Fixed heap buffer over-read in ASN.1 content parsing.
    ([CVE-2026-34180])

  * Fixed PKCS#12 files with PBMAC1 are accepted with short HMAC keys.
    ([CVE-2026-34181])

  * Fixed possible NULL dereference in password-dased CMS decryption.
    ([CVE-2026-42766])

  * Fixed NULL pointer dereference in CRMF `EncryptedValue` decryption.
    ([CVE-2026-42767])

  * Fixed multi-`RecipientInfo` Bleichenbacher Oracle in `CMS_decrypt()`
    and `PKCS7_decrypt()`.
    ([CVE-2026-42768])

  * Fixed trust anchor substitution via `cert`/`issuer` typo in CMP
    `rootCaKeyUpdate`.
    ([CVE-2026-42769])

  * Fixed FFC-DH peer validation uses attacker-supplied `q`.
    ([CVE-2026-42770])

  * Fixed incorrect tag processing for empty messages in AES-GCM-SIV
    and AES-SIV modes.
    ([CVE-2026-45446])
```